### PR TITLE
Add a trailing semicolon to avoid breakage.

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -103,7 +103,7 @@ impl Link {
 
 macro_rules! build_headers {
   ($list:ident, $($x:expr),+) => (
-    $($list.append($x).unwrap())+
+    $($list.append($x).unwrap();)+
   )
 }
 


### PR DESCRIPTION
The code compiles today without the trailing semicolon because of [this bug](https://github.com/rust-lang/rust/issues/34543), which we fixed in https://github.com/rust-lang/rust/pull/34660. The fix is currently in beta.

As far as we are aware, this is the only crate for which we could not implement warnings to preserve backwards comparability (see https://github.com/rust-lang/rust/pull/34660#issuecomment-230699973 for details).