### PR TITLE
Rewrite for testability, error handling,  separation of concerns

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "rust-s3"
-version = "0.3.1"
-authors = ["Drazen Urch"]
+version = "0.4.0"
+authors = ["Drazen Urch", "Nick Stevens"]
 description = "Tiny Rust library for working with Amazon S3."
 repository = "https://github.com/durch/rust-s3"
 readme = "README.md"
@@ -14,9 +14,9 @@ name = "s3"
 path = "src/lib.rs"
 
 [dependencies]
-openssl = "0.7.14"
-time = "0.1.35"
-curl = "0.3.0"
-rustc-serialize = "0.3.22"
-url = "1.2.3"
+chrono = "0.2.0"
+curl = "0.4.0"
+hex = "0.2.0"
 log = "0.3.6"
+rust-crypto = "0.2.0"
+url = "1.2.4"

--- a/examples/simple_crud.rs
+++ b/examples/simple_crud.rs
@@ -1,0 +1,50 @@
+#[macro_use]
+extern crate log;
+extern crate s3;
+
+use std::env;
+use std::str;
+
+use s3::{Bucket, Credentials};
+
+const BUCKET: &'static str = "example-bucket";
+const REGION: &'static str = "us-east-1";
+const MESSAGE: &'static str = "I want to go to S3";
+
+fn load_credentials() -> Credentials {
+    let aws_access = env::var("AWS_ACCESS_KEY_ID").expect("Must specify AWS_ACCESS_KEY_ID");
+    let aws_secret = env::var("AWS_SECRET_ACCESS_KEY").expect("Must specify AWS_SECRET_ACCESS_KEY");
+    Credentials::new(&aws_access, &aws_secret, None)
+}
+
+pub fn main() {
+    // Create Bucket in REGION for BUCKET
+    let credentials = load_credentials();
+    let region = REGION.parse().unwrap();
+    let bucket = Bucket::new(BUCKET, region, credentials);
+
+    // List out contents of directory
+    let (list, code) = bucket.list("", None).unwrap();
+    assert_eq!(200, code);
+    let string = str::from_utf8(&list).unwrap();
+    println!("{}", string);
+
+    // Make sure that our "test_file" doesn't exist, delete it if it does. Note
+    // that the s3 library returns the HTTP code even if it indicates a failure
+    // (i.e. 404) since we can't predict desired usage. For example, you may
+    // expect a 404 to make sure a file doesn't exist.
+    let (_, code) = bucket.delete("test_file").unwrap();
+    assert_eq!(204, code);
+
+    // Put a "test_file" with the contents of MESSAGE at the root of the
+    // bucket.
+    let (_, code) = bucket.put("test_file", MESSAGE.as_bytes(), "text/plain").unwrap();
+    assert_eq!(200, code);
+
+    // Get the "test_file" contents and make sure that the returned message
+    // matches what we sent.
+    let (data, code) = bucket.get("test_file").unwrap();
+    let string = str::from_utf8(&data).unwrap();
+    assert_eq!(200, code);
+    assert_eq!(MESSAGE, string);
+}

--- a/src/signing.rs
+++ b/src/signing.rs
@@ -1,0 +1,245 @@
+//! Implementation of [AWS V4 Signing][link]
+//!
+//! [link]: https://docs.aws.amazon.com/AmazonS3/latest/API/sig-v4-authenticating-requests.html
+
+use std::str;
+
+use chrono::{DateTime, UTC};
+use crypto::digest::Digest;
+use crypto::hmac::Hmac;
+use crypto::mac::Mac;
+use crypto::sha2::Sha256;
+use url::Url;
+
+use super::{Headers, Region};
+
+const SHORT_DATE: &'static str = "%Y%m%d";
+const LONG_DATETIME: &'static str = "%Y%m%dT%H%M%SZ";
+
+/// Encode a URI following the specific requirements of the AWS service.
+pub fn uri_encode(string: &str, encode_slash: bool) -> String {
+    let mut result = String::with_capacity(string.len() * 2);
+    for c in string.chars() {
+        match c {
+            'a'...'z' | 'A'...'Z' | '0'...'9' | '_' | '-' | '~' | '.' => result.push(c),
+            '/' if encode_slash => result.push_str("%2F"),
+            '/' if !encode_slash => result.push('/'),
+            _ => {
+                result.push('%');
+                result.push_str(&format!("{}", c)
+                    .bytes()
+                    .map(|b| format!("{:02X}", b))
+                    .collect::<String>());
+            }
+        }
+    }
+    result
+}
+
+/// Generate a canonical URI string from the given URL.
+pub fn canonical_uri_string(uri: &Url) -> String {
+    uri.path().into()
+}
+
+/// Generate a canonical query string from the query pairs in the given URL.
+pub fn canonical_query_string(uri: &Url) -> String {
+    let mut keyvalues = uri.query_pairs()
+        .map(|(key, value)| uri_encode(&key, true) + "=" + &uri_encode(&value, true))
+        .collect::<Vec<String>>();
+    keyvalues.sort();
+    keyvalues.join("&")
+}
+
+/// Generate a canonical header string from the provided headers.
+pub fn canonical_header_string(headers: &Headers) -> String {
+    let mut keyvalues = headers.iter()
+        .map(|(key, value)| key.to_lowercase() + ":" + value.trim())
+        .collect::<Vec<String>>();
+    keyvalues.sort();
+    keyvalues.join("\n")
+}
+
+/// Generate a signed header string from the provided headers.
+pub fn signed_header_string(headers: &Headers) -> String {
+    let mut keys = headers.iter().map(|(key, _)| key.to_lowercase()).collect::<Vec<String>>();
+    keys.sort();
+    keys.join(";")
+}
+
+/// Generate a canonical request.
+pub fn canonical_request(method: &str, url: &Url, headers: &Headers, sha256: &str) -> String {
+    format!("{method}\n{uri}\n{query_string}\n{headers}\n\n{signed}\n{sha256}",
+            method = method,
+            uri = canonical_uri_string(&url),
+            query_string = canonical_query_string(&url),
+            headers = canonical_header_string(headers),
+            signed = signed_header_string(&headers),
+            sha256 = sha256)
+}
+
+/// Generate an AWS scope string.
+pub fn scope_string(datetime: &DateTime<UTC>, region: Region) -> String {
+    format!("{date}/{region}/s3/aws4_request",
+            date = datetime.format(SHORT_DATE),
+            region = region)
+}
+
+/// Generate the "string to sign" - the value to which the HMAC signing is
+/// applied to sign requests.
+pub fn string_to_sign(datetime: &DateTime<UTC>, region: Region, canonical_req: &str) -> String {
+    let mut hasher = Sha256::new();
+    hasher.input(canonical_req.as_bytes());
+    format!("AWS4-HMAC-SHA256\n{timestamp}\n{scope}\n{hash}",
+            timestamp = datetime.format(LONG_DATETIME),
+            scope = scope_string(datetime, region),
+            hash = hasher.result_str())
+}
+
+/// Generate the AWS signing key, derived from the secret key, date, region,
+/// and service name.
+pub fn signing_key(datetime: &DateTime<UTC>,
+                   secret_key: &str,
+                   region: Region,
+                   service: &str)
+                   -> Vec<u8> {
+    let sha256 = Sha256::new();
+    let secret = String::from("AWS4") + secret_key;
+    let mut date_hmac = Hmac::new(sha256, secret.as_bytes());
+    date_hmac.input(datetime.format(SHORT_DATE).to_string().as_bytes());
+    let mut region_hmac = Hmac::new(sha256, &date_hmac.result().code());
+    region_hmac.input(region.to_string().as_bytes());
+    let mut service_hmac = Hmac::new(sha256, &region_hmac.result().code());
+    service_hmac.input(service.as_bytes());
+    let mut signing_hmac = Hmac::new(sha256, &service_hmac.result().code());
+    signing_hmac.input("aws4_request".as_bytes());
+    signing_hmac.result().code().into()
+}
+
+/// Generate the AWS authorization header.
+pub fn authorization_header(access_key: &str,
+                            datetime: &DateTime<UTC>,
+                            region: Region,
+                            signed_headers: &str,
+                            signature: &str)
+                            -> String {
+    format!("AWS4-HMAC-SHA256 Credential={access_key}/{scope},\
+            SignedHeaders={signed_headers},Signature={signature}",
+            access_key = access_key,
+            scope = scope_string(datetime, region),
+            signed_headers = signed_headers,
+            signature = signature)
+}
+
+#[cfg(test)]
+mod tests {
+    use std::str;
+
+    use chrono::{TimeZone, UTC};
+    use crypto::hmac::Hmac;
+    use crypto::mac::Mac;
+    use crypto::sha2::Sha256;
+    use hex::ToHex;
+    use url::Url;
+
+    use ::Headers;
+    use super::*;
+
+    #[test]
+    fn test_base_url_encode() {
+        // Make sure parsing doesn't remove extra slashes, as normalization
+        // will mess up the path lookup.
+        let url = Url::parse("http://s3.amazonaws.com/examplebucket///foo//bar//baz").unwrap();
+        let canonical = canonical_uri_string(&url);
+        assert_eq!("/examplebucket///foo//bar//baz", canonical);
+    }
+
+    #[test]
+    fn test_query_string_encode() {
+        let url = Url::parse("http://s3.amazonaws.com/examplebucket?\
+                              prefix=somePrefix&marker=someMarker&max-keys=20")
+            .unwrap();
+        let canonical = canonical_query_string(&url);
+        assert_eq!("marker=someMarker&max-keys=20&prefix=somePrefix", canonical);
+
+        let url = Url::parse("http://s3.amazonaws.com/examplebucket?acl").unwrap();
+        let canonical = canonical_query_string(&url);
+        assert_eq!("acl=", canonical);
+
+        let url = Url::parse("http://s3.amazonaws.com/examplebucket?\
+                              key=with%20space&also+space=with+plus")
+            .unwrap();
+        let canonical = canonical_query_string(&url);
+        assert_eq!("also%20space=with%20plus&key=with%20space", canonical);
+    }
+
+    #[test]
+    fn test_headers_encode() {
+        let headers: Headers = vec![("X-Amz-Date".into(), "20130708T220855Z".into()),
+                                    ("FOO".into(), "bAr".into()),
+                                    ("host".into(), "s3.amazonaws.com".into())]
+            .into_iter()
+            .collect();
+        let canonical = canonical_header_string(&headers);
+        let expected = "foo:bAr\nhost:s3.amazonaws.com\nx-amz-date:20130708T220855Z";
+        assert_eq!(expected, canonical);
+
+        let signed = signed_header_string(&headers);
+        assert_eq!("foo;host;x-amz-date", signed);
+    }
+
+    #[test]
+    fn test_aws_signing_key() {
+        let key = "wJalrXUtnFEMI/K7MDENG+bPxRfiCYEXAMPLEKEY";
+        let expected = "c4afb1cc5771d871763a393e44b703571b55cc28424d1a5e86da6ed3c154a4b9";
+        let datetime = UTC.ymd(2015, 8, 30).and_hms(0, 0, 0);
+        let signature = signing_key(&datetime, key, "us-east-1".parse().unwrap(), "iam");
+        assert_eq!(expected, signature.to_hex());
+    }
+
+    const EXPECTED_SHA: &'static str = "e3b0c44298fc1c149afbf4c8996fb924\
+                                        27ae41e4649b934ca495991b7852b855";
+
+    #[cfg_attr(rustfmt, rustfmt_skip)]
+    const EXPECTED_CANONICAL_REQUEST: &'static str =
+        "GET\n\
+         /test.txt\n\
+         \n\
+         host:examplebucket.s3.amazonaws.com\n\
+         range:bytes=0-9\n\
+         x-amz-content-sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855\n\
+         x-amz-date:20130524T000000Z\n\
+         \n\
+         host;range;x-amz-content-sha256;x-amz-date\n\
+         e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855";
+
+    #[cfg_attr(rustfmt, rustfmt_skip)]
+    const EXPECTED_STRING_TO_SIGN: &'static str =
+        "AWS4-HMAC-SHA256\n\
+         20130524T000000Z\n\
+         20130524/us-east-1/s3/aws4_request\n\
+         7344ae5b7ee6c3e7e6b0fe0640412a37625d1fbfff95c48bbb2dc43964946972";
+
+    #[test]
+    fn test_signing() {
+        let url = Url::parse("https://examplebucket.s3.amazonaws.com/test.txt").unwrap();
+        let headers: Headers = vec![("X-Amz-Date".into(), "20130524T000000Z".into()),
+                                    ("range".into(), "bytes=0-9".into()),
+                                    ("host".into(), "examplebucket.s3.amazonaws.com".into()),
+                                    ("X-Amz-Content-Sha256".into(), EXPECTED_SHA.into())]
+            .into_iter()
+            .collect();
+        let canonical = canonical_request("GET", &url, &headers, EXPECTED_SHA);
+        assert_eq!(EXPECTED_CANONICAL_REQUEST, canonical);
+
+        let datetime = UTC.ymd(2013, 5, 24).and_hms(0, 0, 0);
+        let string_to_sign = string_to_sign(&datetime, "us-east-1".parse().unwrap(), &canonical);
+        assert_eq!(EXPECTED_STRING_TO_SIGN, string_to_sign);
+
+        let expected = "f0e8bdb87c964420e857bd35b5d6ed310bd44f0170aba48dd91039c6036bdb41";
+        let secret = "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY";
+        let signing_key = signing_key(&datetime, secret, "us-east-1".parse().unwrap(), "s3");
+        let mut hmac = Hmac::new(Sha256::new(), &signing_key);
+        hmac.input(string_to_sign.as_bytes());
+        assert_eq!(expected, hmac.result().code().to_hex());
+    }
+}


### PR DESCRIPTION
First off, thank you for writing this library. The API is exactly at the level it should be for 99% of the interactions that people have with S3, as opposed to the extremely detailed APIs of something like rusoto or aws_sdk_rust.

What I found when working with the library, though, is that many potential sources of errors were handled with `panic!`. This was unworkable for my needs since I would be running this from a server. I started by rewriting chunks of the code to use the Rust `Result` type, and started to notice more and more places where I could "rustify" code. In the end I reworked quite a bit, and ended up with something that I think will be easier to use, maintain, and extend.

I'm opening this PR mainly as an option for you - if you like the changes I've made, great! I'd love to have this code live on in rust-s3. If not, no problem! I'll keep this code local to my own branch, and will absolutely make sure that you continue to get credit and proper license handling under MIT. I may opt to change the name to avoid confusion as well.

Here's a hitlist of changes:

  * All authentication is split out to a separate module, and could potentially be replaced by another library like warheadhateus if desired
  * S3 functions are now calls on the Bucket type
  * Stringly type region has been converted to an enum with appropriate conversion functions.
  * Unit tests added across all authentication functions.
  * Operational example added - simply requires S3 credentials and a bucket name to perform a CRUD test.
  * All functions and methods properly handle or return errors - no more panics or unwraps
  * openssl is replaced with rust-crypto to eliminate system library dependency
  * Docs for all public functions added, and `warn(missing_docs)` added at module level
  * Credentials are their own type and accept a Token for use with temporary credentials.
  * Requests use the bucket name in the URL path, not as a subdomain. This eliminates TLS issues for non-matching domain names.
  * List command now supports delimiters