### PR TITLE
Large file sizes and missing fields when listing bucket contents

### DIFF
--- a/src/serde_types.rs
+++ b/src/serde_types.rs
@@ -28,7 +28,7 @@ pub struct Object {
     pub key: String,
     #[serde(rename = "Owner")]
     /// Bucket owner
-    pub owner: Owner,
+    pub owner: Option<Owner>,
     #[serde(rename = "Size")]
     /// Size in bytes of the object.
     pub size: i32,
@@ -46,10 +46,10 @@ pub struct ListBucketResult {
     /// is true), you can use the key name in this field as a marker in the subsequent request
     /// to get next set of objects. Amazon S3 lists objects in UTF-8 character encoding in
     /// lexicographical order.
-    pub next_marker: String,
+    pub next_marker: Option<String>,
     #[serde(rename = "Delimiter")]
     /// A delimiter is a character you use to group keys.
-    pub delimiter: String,
+    pub delimiter: Option<String>,
     #[serde(rename = "MaxKeys")]
     /// Sets the maximum number of keys returned in the response body.
     pub max_keys: i32,
@@ -59,10 +59,10 @@ pub struct ListBucketResult {
     #[serde(rename = "Marker")]
     /// Indicates where in the bucket listing begins. Marker is included in the response if
     /// it was sent with the request.
-    pub marker: String,
+    pub marker: Option<String>,
     #[serde(rename = "EncodingType")]
     /// Specifies the encoding method to used
-    pub encoding_type: String,
+    pub encoding_type: Option<String>,
     #[serde(rename = "IsTruncated")]
     ///  Specifies whether (true) or not (false) all of the results were returned.
     ///  If the number of results exceeds that specified by MaxKeys, all of the results
@@ -74,7 +74,7 @@ pub struct ListBucketResult {
     #[serde(rename = "CommonPrefixs")]
     /// All of the keys rolled up into a common prefix count as a single return when
     /// calculating the number of returns.
-    pub common_prefixes: Vec<CommonPrefix>,
+    pub common_prefixes: Option<Vec<CommonPrefix>>,
 }
 
 /// CommonPrefix is used to group keys

--- a/src/serde_types.rs
+++ b/src/serde_types.rs
@@ -31,7 +31,7 @@ pub struct Object {
     pub owner: Option<Owner>,
     #[serde(rename = "Size")]
     /// Size in bytes of the object.
-    pub size: i32,
+    pub size: u64,
 }
 
 


### PR DESCRIPTION
Hey!

I was trying to list the contents of a few buckets, but encountered a couple of problems:

- File sizes larger than `i32::MAX` cause Serde XML to complain about receiving a string instead of `i32` (in my case, I had a 6GB file that caused this), so I changed the type of `Owner.size` to `u64`.
- For some buckets, the fields `Owner`, `NextMarker`, `Delimiter`, `Marker`, `EncodingType`, and `CommonPrefixes` were missing in the API response (again, causing Serde XML to fail), so I made them optional.

These are of course breaking changes since they change public types, but for me they work ;-) 