### PR TITLE
Fixed the bucket list API

### DIFF
--- a/src/bucket.rs
+++ b/src/bucket.rs
@@ -157,7 +157,7 @@ impl Bucket {
         let request = Request::new(self, "/", command);
         let result = request.execute()?;
         let result_string = String::from_utf8_lossy(&result.0);
-        if 200 <= result.1 && result.1 < 300 {
+        if result.1 < 300 {
             let deserialized: ListBucketResult = serde_xml::deserialize(result_string.as_bytes())?;
             Ok((deserialized, result.1))
         } else {

--- a/src/bucket.rs
+++ b/src/bucket.rs
@@ -6,9 +6,9 @@ use credentials::Credentials;
 use command::Command;
 use region::Region;
 use request::{Request, Headers, Query};
-use serde_types::ListBucketResult;
+use serde_types::{ListBucketResult, AwsError};
 
-use error::S3Result;
+use error::{S3Result, ErrorKind};
 
 /// # Example
 /// ```
@@ -157,8 +157,18 @@ impl Bucket {
         let request = Request::new(self, "/", command);
         let result = request.execute()?;
         let result_string = String::from_utf8_lossy(&result.0);
-        let deserialized: ListBucketResult = serde_xml::deserialize(result_string.as_bytes())?;
-        Ok((deserialized, result.1))
+        if 200 <= result.1 && result.1 < 300 {
+            println!("{}", result_string);
+            let deserialized: ListBucketResult = serde_xml::deserialize(result_string.as_bytes())?;
+            Ok((deserialized, result.1))
+        } else {
+            let deserialized: AwsError = serde_xml::deserialize(result_string.as_bytes())?;
+            let err = ErrorKind::AwsError{
+                info: deserialized,
+                status: result.1,
+                body: result_string.into_owned() };
+            Err(err.into())
+        }
     }
 
     /// Get a reference to the name of the S3 bucket.

--- a/src/bucket.rs
+++ b/src/bucket.rs
@@ -158,7 +158,6 @@ impl Bucket {
         let result = request.execute()?;
         let result_string = String::from_utf8_lossy(&result.0);
         if 200 <= result.1 && result.1 < 300 {
-            println!("{}", result_string);
             let deserialized: ListBucketResult = serde_xml::deserialize(result_string.as_bytes())?;
             Ok((deserialized, result.1))
         } else {

--- a/src/error.rs
+++ b/src/error.rs
@@ -7,5 +7,8 @@ error_chain! {
             SerdeXML(::serde_xml::Error);
             Curl(::curl::Error);
         }
-
+        errors {
+            AwsError { info: ::serde_types::AwsError, status: u32, body: String } {
+            }
+        }
     }

--- a/src/serde_types.rs
+++ b/src/serde_types.rs
@@ -28,7 +28,7 @@ pub struct Object {
     pub key: String,
     #[serde(rename = "Owner")]
     /// Bucket owner
-    pub owner: Owner,
+    pub owner: Option<Owner>,
     #[serde(rename = "Size")]
     /// Size in bytes of the object.
     pub size: i32,
@@ -46,10 +46,10 @@ pub struct ListBucketResult {
     /// is true), you can use the key name in this field as a marker in the subsequent request
     /// to get next set of objects. Amazon S3 lists objects in UTF-8 character encoding in
     /// lexicographical order.
-    pub next_marker: String,
+    pub next_marker: Option<String>,
     #[serde(rename = "Delimiter")]
     /// A delimiter is a character you use to group keys.
-    pub delimiter: String,
+    pub delimiter: Option<String>,
     #[serde(rename = "MaxKeys")]
     /// Sets the maximum number of keys returned in the response body.
     pub max_keys: i32,
@@ -59,19 +59,19 @@ pub struct ListBucketResult {
     #[serde(rename = "Marker")]
     /// Indicates where in the bucket listing begins. Marker is included in the response if
     /// it was sent with the request.
-    pub marker: String,
+    pub marker: Option<String>,
     #[serde(rename = "EncodingType")]
     /// Specifies the encoding method to used
-    pub encoding_type: String,
+    pub encoding_type: Option<String>,
     #[serde(rename = "IsTruncated")]
     ///  Specifies whether (true) or not (false) all of the results were returned.
     ///  If the number of results exceeds that specified by MaxKeys, all of the results
     ///  might not be returned.
     pub is_truncated: bool,
-    #[serde(rename = "Contents")]
+    #[serde(rename = "Contents", default)]
     /// Metadata about each object returned.
     pub contents: Vec<Object>,
-    #[serde(rename = "CommonPrefixs")]
+    #[serde(rename = "CommonPrefixs", default)]
     /// All of the keys rolled up into a common prefix count as a single return when
     /// calculating the number of returns.
     pub common_prefixes: Vec<CommonPrefix>,

--- a/src/serde_types.rs
+++ b/src/serde_types.rs
@@ -84,3 +84,13 @@ pub struct CommonPrefix {
     /// Keys that begin with the indicated prefix.
     pub prefix: String,
 }
+
+#[derive(Deserialize, Debug)]
+pub struct AwsError {
+    #[serde(rename = "Code")]
+    pub code: String,
+    #[serde(rename = "Message")]
+    pub message: String,
+    #[serde(rename = "RequestId")]
+    pub request_id: String,
+}


### PR DESCRIPTION
The bucket list API is currently dysfunctional. AWS sends responses that fail to parse, as Serde expects the fields to exist in responses. Additionally, when the request fails, the developer doesn't get very good information why.

This PR fixes the bucket list API by making non-default fields optional. In addition, it makes the errors returned by AWS into first class errors in the library.

The other methods need to be updated with AWS errors too – this is just the first push, but at least it makes the bucket listing API work.