### PR TITLE
Solved an issue with parsing ListBucketResult returned from S3.

### DIFF
--- a/src/deserializer.rs
+++ b/src/deserializer.rs
@@ -1,0 +1,10 @@
+use serde::de::*;
+
+pub fn bool_deserializer<'de, D>(d: D) -> Result<bool, D::Error> where D: Deserializer<'de> {
+    let s = String::deserialize(d)?;
+    match &s[..] {
+        "true" => Ok(true),
+        "false" => Ok(false),
+        other => Err(D::Error::custom(format!("got {}, but expected `true` or `false`", other))),
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -21,6 +21,7 @@ pub mod region;
 pub mod request;
 pub mod serde_types;
 pub mod signing;
+pub mod deserializer;
 
 const LONG_DATE: &'static str = "%Y%m%dT%H%M%SZ";
 const EMPTY_PAYLOAD_SHA: &'static str = "e3b0c44298fc1c149afbf4c8996fb924\

--- a/src/serde_types.rs
+++ b/src/serde_types.rs
@@ -63,7 +63,7 @@ pub struct ListBucketResult {
     #[serde(rename = "EncodingType")]
     /// Specifies the encoding method to used
     pub encoding_type: Option<String>,
-    #[serde(rename = "IsTruncated")]
+    #[serde(rename = "IsTruncated", deserialize_with = "super::deserializer::bool_deserializer")]
     ///  Specifies whether (true) or not (false) all of the results were returned.
     ///  If the number of results exceeds that specified by MaxKeys, all of the results
     ///  might not be returned.

--- a/src/signing.rs
+++ b/src/signing.rs
@@ -12,6 +12,9 @@ use region::Region;
 use request::Headers;
 use sha2::{Digest, Sha256};
 
+use serde_xml;
+use serde_types::ListBucketResult;
+
 const SHORT_DATE: &'static str = "%Y%m%d";
 const LONG_DATETIME: &'static str = "%Y%m%dT%H%M%SZ";
 
@@ -236,5 +239,22 @@ mod tests {
         let mut hmac = Hmac::<Sha256>::new(&signing_key);
         hmac.input(string_to_sign.as_bytes());
         assert_eq!(expected, hmac.result().code().to_hex());
+    }
+
+    #[test]
+    fn test_parse_list_bucket_result() {
+        let result_string = r###"
+            <?xml version="1.0" encoding="UTF-8"?>
+            <ListBucketResult
+                xmlns="http://s3.amazonaws.com/doc/2006-03-01/">
+                <Name>RelationalAI</Name>
+                <Prefix>/</Prefix>
+                <KeyCount>0</KeyCount>
+                <MaxKeys>1000</MaxKeys>
+                <IsTruncated>true</IsTruncated>
+            </ListBucketResult>
+        "###;
+        let deserialized: ListBucketResult = serde_xml::deserialize(result_string.as_bytes()).expect("Parse error!");
+        assert!(deserialized.is_truncated);
     }
 }


### PR DESCRIPTION
The main issue was possibly because of a change in the implementation of serde-rs or serde-xml-rs and the details are here: https://github.com/RReverser/serde-xml-rs/issues/44

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/durch/rust-s3/17)
<!-- Reviewable:end -->
