### PR TITLE
Moved error handling to the Request object, so every method now checks for errors.

### DIFF
--- a/src/bucket.rs
+++ b/src/bucket.rs
@@ -1,14 +1,14 @@
 use std::collections::HashMap;
 use std::mem;
+
 use serde_xml;
 
 use credentials::Credentials;
 use command::Command;
 use region::Region;
 use request::{Request, Headers, Query};
-use serde_types::{ListBucketResult, AwsError};
-
-use error::{S3Result, ErrorKind};
+use serde_types::ListBucketResult;
+use error::S3Result;
 
 /// # Example
 /// ```
@@ -157,17 +157,8 @@ impl Bucket {
         let request = Request::new(self, "/", command);
         let result = request.execute()?;
         let result_string = String::from_utf8_lossy(&result.0);
-        if result.1 < 300 {
-            let deserialized: ListBucketResult = serde_xml::deserialize(result_string.as_bytes())?;
-            Ok((deserialized, result.1))
-        } else {
-            let deserialized: AwsError = serde_xml::deserialize(result_string.as_bytes())?;
-            let err = ErrorKind::AwsError{
-                info: deserialized,
-                status: result.1,
-                body: result_string.into_owned() };
-            Err(err.into())
-        }
+        let deserialized: ListBucketResult = serde_xml::deserialize(result_string.as_bytes())?;
+        Ok((deserialized, result.1))
     }
 
     /// Get a reference to the name of the S3 bucket.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,7 +7,6 @@ extern crate hex;
 extern crate hmac;
 #[macro_use]
 extern crate serde_derive;
-extern crate serde;
 extern crate serde_xml_rs as serde_xml;
 extern crate sha2;
 extern crate url;


### PR DESCRIPTION
Last time I implemented an error handling for one function. Now that I'm using many other functions too, I realised, upon encountering an error, that I completely forgot about the others!

You can always see from the HTTP status returned by AWS that some error has happened, if its 400 or over. So it makes sense to implement a general error handling. Also, the AwsError type contains the fields that, according to the API, are always populated. This is enough to get a gist of of the error.

At the moment the methods in this crate happily return with the "no error" path, even if error has happened. This is very surprising from the user perspective, since the methods return a `S3Result`. This PR fixes this by checking the errors at the `request.rs` file, upon finishing a request.