### PR TITLE
Add digital ocean's nyc3 region to the list of possible regions

### DIFF
--- a/src/region.rs
+++ b/src/region.rs
@@ -46,6 +46,8 @@ pub enum Region {
     EuWest2,
     /// sa-east-1
     SaEast1,
+    /// Digital Ocean nyc3
+    DoNyc3,
 }
 
 impl fmt::Display for Region {
@@ -66,6 +68,7 @@ impl fmt::Display for Region {
             EuWest1 => write!(f, "eu-west-1"),
             EuWest2 => write!(f, "eu-west-2"),
             SaEast1 => write!(f, "sa-east-1"),
+            DoNyc3 => write!(f, "nyc3"),
         }
     }
 }
@@ -90,6 +93,7 @@ impl FromStr for Region {
             "eu-west-1" => Ok(EuWest1),
             "eu-west-2" => Ok(EuWest2),
             "sa-east-1" => Ok(SaEast1),
+            "nyc3" => Ok(DoNyc3),
             _ => Err(s.to_string().into()),
         }
     }
@@ -115,6 +119,7 @@ impl Region {
             EuWest1 => "s3-eu-west-1.amazonaws.com",
             EuWest2 => "s3-eu-west-2.amazonaws.com",
             SaEast1 => "s3-sa-east-1.amazonaws.com",
+            DoNyc3 => "nyc3.digitaloceanspaces.com",
         }
     }
 }


### PR DESCRIPTION
Digital Ocean is rolling out Spaces.  Spaces is compatible with Amazon S3.  This patch makes this library work with Digital Ocean Spaces.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/durch/rust-s3/23)
<!-- Reviewable:end -->
