### PR TITLE
Fixed a typo when deserializing common prefixes from a bucket listing

### DIFF
--- a/src/serde_types.rs
+++ b/src/serde_types.rs
@@ -72,7 +72,7 @@ pub struct ListBucketResult {
     #[serde(rename = "Contents", default)]
     /// Metadata about each object returned.
     pub contents: Vec<Object>,
-    #[serde(rename = "CommonPrefixs", default)]
+    #[serde(rename = "CommonPrefixes", default)]
     /// All of the keys rolled up into a common prefix count as a single return when
     /// calculating the number of returns.
     pub common_prefixes: Option<Vec<CommonPrefix>>,


### PR DESCRIPTION
This change lines up the name of the field for common prefixes from rust-rs with the one used by S3.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/durch/rust-s3/25)
<!-- Reviewable:end -->
