### PR TITLE
Do not use real user credentials in unit tests

### DIFF
--- a/src/bucket.rs
+++ b/src/bucket.rs
@@ -12,6 +12,10 @@ use error::S3Result;
 
 /// # Example
 /// ```
+/// # // Fake  credentials so we don't access user's real credentials in tests
+/// # use std::env;
+/// # env::set_var("AWS_ACCESS_KEY_ID", "AKIAIOSFODNN7EXAMPLE");
+/// # env::set_var("AWS_SECRET_ACCESS_KEY", "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY");
 /// use s3::bucket::Bucket;
 /// use s3::credentials::Credentials;
 ///
@@ -35,6 +39,10 @@ impl Bucket {
     ///
     /// # Example
     /// ```
+    /// # // Fake  credentials so we don't access user's real credentials in tests
+    /// # use std::env;
+    /// # env::set_var("AWS_ACCESS_KEY_ID", "AKIAIOSFODNN7EXAMPLE");
+    /// # env::set_var("AWS_SECRET_ACCESS_KEY", "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY");
     /// use s3::bucket::Bucket;
     /// use s3::credentials::Credentials;
     ///

--- a/src/credentials.rs
+++ b/src/credentials.rs
@@ -5,17 +5,47 @@ use ini::Ini;
 /// AWS access credentials: access key, secret key, and optional token.
 ///
 /// # Example
+///
+/// Loads from the standard AWS credentials file with the given profile name,
+/// defaults to "default".
+///
+/// ```no_run
+/// # // Do not execute this as it would cause unit tests to attempt to access
+/// # // real user credentials.
+/// use s3::credentials::Credentials;
+///
+/// // Load credentials from `[default]` profile
+/// let credentials = Credentials::default();
+///
+/// // Also loads credentials from `[default]` profile
+/// let credentials = Credentials::new(None, None, None, None);
+///
+/// // Load credentials from `[my-profile]` profile
+/// let credentials = Credentials::new(None, None, None, Some("my-profile".into()));
+/// ```
+///
+/// Credentials may also be initialized directly or by the following environment variables:
+///
+///   - `AWS_ACCESS_KEY_ID`,
+///   - `AWS_SECRET_ACCESS_KEY`
+///   - `AWS_SESSION_TOKEN`
+///
+/// The order of preference is arguments, then environment, and finally AWS
+/// credentials file.
+///
 /// ```
 /// use s3::credentials::Credentials;
 ///
-/// // Loads credentials from environment AWS_ACCESS_KEY_ID, AWS_SECRET_ACCESS_KEY, and
-/// // AWS_SESSION_TOKEN variables
-/// // or from the standard AWS credentials file with the given
-/// // profile name, defaults to "default".
-/// // Initialize directly with key ID, secret key, optional token,
-/// // if None are provided fallback is env than profile file
+/// // Load credentials directly
+/// let access_key = String::from("AKIAIOSFODNN7EXAMPLE");
+/// let secret_key = String::from("wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY");
+/// let credentials = Credentials::new(Some(access_key), Some(secret_key), None, None);
+///
+/// // Load credentials from the environment
+/// use std::env;
+/// env::set_var("AWS_ACCESS_KEY_ID", "AKIAIOSFODNN7EXAMPLE");
+/// env::set_var("AWS_SECRET_ACCESS_KEY", "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY");
 /// let credentials = Credentials::new(None, None, None, None);
-/// let credentials = Credentials::default();
 /// ```
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct Credentials {

--- a/src/request.rs
+++ b/src/request.rs
@@ -238,10 +238,18 @@ mod tests {
     use credentials::Credentials;
     use request::Request;
 
+    // Fake keys - otherwise using Credentials::default will use actual user
+    // credentials if they exist.
+    fn fake_credentials() -> Credentials {
+        const ACCESS_KEY: &'static str = "AKIAIOSFODNN7EXAMPLE";
+        const SECRET_KEY: &'static str = "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY";
+        Credentials::new(Some(ACCESS_KEY.into()), Some(SECRET_KEY.into()), None, None)
+    }
+
     #[test]
     fn url_uses_https_by_default() {
         let region = "custom-region".parse().unwrap();
-        let bucket = Bucket::new("my-first-bucket", region, Credentials::default());
+        let bucket = Bucket::new("my-first-bucket", region, fake_credentials());
         let path = "/my-first/path";
         let request = Request::new(&bucket, path, Command::Get);
 
@@ -256,7 +264,7 @@ mod tests {
     #[test]
     fn url_uses_scheme_from_custom_region_if_defined() {
         let region = "http://custom-region".parse().unwrap();
-        let bucket = Bucket::new("my-second-bucket", region, Credentials::default());
+        let bucket = Bucket::new("my-second-bucket", region, fake_credentials());
         let path = "/my-second/path";
         let request = Request::new(&bucket, path, Command::Get);
 


### PR DESCRIPTION
Changes made to the `Credentials` type cause it fall back to loading credentials from the config file usually kept at `~/.aws/credentials`. This is certainly useful in normal operation, but when running unit tests we don't want to be accidently using people's real keys.

Note that the keys I've used as stand-ins are all example credentials from the AWS documentation, not real keys.

@durch

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/durch/rust-s3/33)
<!-- Reviewable:end -->
