### PR TITLE
Convert to using reqwest library

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,10 +15,10 @@ path = "src/lib.rs"
 
 [dependencies]
 chrono = "^0.4.0"
-curl = "^0.4.8"
 error-chain = "^0.10.0"
 hex = "^0.2.0"
 hmac = "^0.4.2"
+reqwest = "^0.9.1"
 serde_derive = "^1.0.11"
 serde = "^1.0.11"
 serde-xml-rs = "^0.2.1"

--- a/src/command.rs
+++ b/src/command.rs
@@ -1,3 +1,5 @@
+use reqwest::Method;
+
 pub enum Command<'a> {
     Put {
         content: &'a [u8],
@@ -13,11 +15,11 @@ pub enum Command<'a> {
 }
 
 impl<'a> Command<'a> {
-    pub fn http_verb(&self) -> &'static str {
+    pub fn http_verb(&self) -> Method {
         match *self {
-            Command::Get | Command::List { .. }=> "GET",
-            Command::Put { .. } => "PUT",
-            Command::Delete => "DELETE"
+            Command::Get | Command::List { .. } => Method::GET,
+            Command::Put { .. } => Method::PUT,
+            Command::Delete => Method::DELETE,
         }
     }
 }

--- a/src/error.rs
+++ b/src/error.rs
@@ -4,10 +4,13 @@ error_chain! {
         }
         foreign_links {
             FromUtf8(::std::string::FromUtf8Error);
+            IoError(::std::io::Error);
             SerdeXML(::serde_xml::Error);
-            Curl(::curl::Error);
             Env(::std::env::VarError);
             Ini(::ini::ini::Error);
+            Reqwest(::reqwest::Error);
+            ReqwestInvalidHeaderName(::reqwest::header::InvalidHeaderName);
+            ReqwestInvalidHeaderValue(::reqwest::header::InvalidHeaderValue);
         }
         errors {
             AwsError { info: ::serde_types::AwsError, status: u32, body: String } {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,10 +1,10 @@
 //! Simple access to Amazon Web Service's (AWS) Simple Storage Service (S3)
 extern crate chrono;
-extern crate curl;
 #[macro_use]
 extern crate error_chain;
 extern crate hex;
 extern crate hmac;
+extern crate reqwest;
 extern crate serde;
 #[macro_use]
 extern crate serde_derive;


### PR DESCRIPTION
When this library was originally created there wasn't a good pure-Rust solution for synchronous HTTP requests. That library (reqwest) now exists, so convert existing Curl-based code to use it.

This primarily reduces the number of external system/C-language dependencies for the library, but the reqwest library also has much nicer ergonomics than curl.

@durch

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/durch/rust-s3/34)
<!-- Reviewable:end -->
