### PR TITLE
Finalize 0.18.0-beta

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rust-s3"
-version = "0.18.0-beta1"
+version = "0.18.0-beta2"
 authors = ["Drazen Urch", "Nick Stevens"]
 description = "Tiny Rust library for working with Amazon S3."
 repository = "https://github.com/durch/rust-s3"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rust-s3"
-version = "0.18.0-beta"
+version = "0.18.0-beta1"
 authors = ["Drazen Urch", "Nick Stevens"]
 description = "Tiny Rust library for working with Amazon S3."
 repository = "https://github.com/durch/rust-s3"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rust-s3"
-version = "0.18.0-beta2"
+version = "0.18.0-beta3"
 authors = ["Drazen Urch", "Nick Stevens"]
 description = "Tiny Rust library for working with Amazon S3."
 repository = "https://github.com/durch/rust-s3"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rust-s3"
-version = "0.18.0-beta3"
+version = "0.18.0-beta4"
 authors = ["Drazen Urch", "Nick Stevens"]
 description = "Tiny Rust library for working with Amazon S3."
 repository = "https://github.com/durch/rust-s3"
@@ -28,7 +28,6 @@ url = "^1.5.1"
 rust-ini = "^0.9"
 dirs = "^1.0"
 futures = "^0.1.28"
-snafu = {version = "^0.5", features = ["futures-01"]}
 
 [features]
 no-verify-ssl = []

--- a/src/bucket.rs
+++ b/src/bucket.rs
@@ -444,7 +444,7 @@ impl Bucket {
     /// let credentials = Credentials::default();
     /// let bucket = Bucket::new(bucket_name, region, credentials).unwrap();
     ///
-    /// let results = bucket.list_all("/", Some("/")).unwrap();
+    /// let results = bucket.list_all("/".to_string(), Some("/".to_string())).unwrap();
     /// for (list, code) in results {
     ///     assert_eq!(200, code);
     ///     println!("{:?}", list);
@@ -484,7 +484,7 @@ impl Bucket {
     /// let credentials = Credentials::default();
     /// let bucket = Bucket::new(bucket_name, region, credentials).unwrap();
     ///
-    /// let results = bucket.list_all_async("/", Some("/")).and_then(|list| {
+    /// let results = bucket.list_all_async("/".to_string(), Some("/".to_string())).and_then(|list| {
     ///     println!("{:?}", list);
     ///     Ok(())
     /// });

--- a/src/bucket.rs
+++ b/src/bucket.rs
@@ -489,10 +489,11 @@ impl Bucket {
     ///     Ok(())
     /// });
     /// ```
-    pub fn list_all_async(&self, prefix: String, delimiter: Option<String>) -> impl Future<Item=Vec<ListBucketResult>, Error=S3Error> + Send + '_ {
+    pub fn list_all_async(&self, prefix: String, delimiter: Option<String>) -> impl Future<Item=Vec<ListBucketResult>, Error=S3Error> + Send {
+        let the_bucket = self.to_owned();
         let list_entire_bucket = loop_fn((None, Vec::new()), move |(continuation_token, results): (Option<String>, Vec<ListBucketResult>)| {
             let mut inner_results = results;
-            self.list_page_async(prefix.clone(), delimiter.clone(), continuation_token).and_then(|(result, _status_code)| {
+            the_bucket.list_page_async(prefix.clone(), delimiter.clone(), continuation_token).and_then(|(result, _status_code)| {
                 inner_results.push(result.clone());
                 match result.next_continuation_token {
                     Some(token) => Ok(Loop::Continue((Some(token), inner_results))),

--- a/src/command.rs
+++ b/src/command.rs
@@ -16,7 +16,7 @@ pub enum Command<'a> {
     ListBucket {
         prefix: &'a str,
         delimiter: Option<&'a str>,
-        continuation_token: Option<&'a str>
+        continuation_token: Option<String>
     },
     GetBucketLocation
 }

--- a/src/command.rs
+++ b/src/command.rs
@@ -1,5 +1,6 @@
 use reqwest::Method;
 
+#[derive(Clone)]
 pub enum Command<'a> {
     DeleteObject,
     DeleteObjectTagging,
@@ -14,8 +15,8 @@ pub enum Command<'a> {
     },
 
     ListBucket {
-        prefix: &'a str,
-        delimiter: Option<&'a str>,
+        prefix: String,
+        delimiter: Option<String>,
         continuation_token: Option<String>
     },
     GetBucketLocation

--- a/src/credentials.rs
+++ b/src/credentials.rs
@@ -1,30 +1,7 @@
 use std::env;
 use dirs;
 use ini::Ini;
-use snafu::{ResultExt, Snafu};
-
-#[derive(Debug, Snafu)]
-pub enum Error {
-    VarError {
-        source: std::env::VarError
-    },
-    HomeDir,
-    IniError {
-        source: ini::ini::Error
-    },
-    #[snafu(display("Section [{}] not found in {}", section, profile))]
-    AwsMissingSection {
-        section: String,
-        profile: String
-    },
-    #[snafu(display("Missing {} in {}", part, profile))]
-    AwsConfigError {
-        part: String,
-        profile: String
-    }
-}
-
-type S3Result<T, E = Error> = std::result::Result<T, E>;
+use error::{err, S3Result};
 
 /// AWS access credentials: access key, secret key, and optional token.
 ///
@@ -125,8 +102,8 @@ impl Credentials {
     }
 
     fn from_env() -> S3Result<Credentials> {
-        let access_key = env::var("AWS_ACCESS_KEY_ID").context(VarError)?;
-        let secret_key = env::var("AWS_SECRET_ACCESS_KEY").context(VarError)?;
+        let access_key = env::var("AWS_ACCESS_KEY_ID")?;
+        let secret_key = env::var("AWS_SECRET_ACCESS_KEY")?;
         let token = match env::var("AWS_SESSION_TOKEN") {
             Ok(x) => Some(x),
             Err(_) => None
@@ -137,29 +114,29 @@ impl Credentials {
     fn from_profile(section: Option<String>) -> S3Result<Credentials> {
         let home_dir = match dirs::home_dir() {
             Some(path) => Ok(path),
-            None => Err(Error::HomeDir),
+            None => Err(err("Invalid home dir")),
         };
         let profile = format!("{}/.aws/credentials", home_dir?.display());
-        let conf = Ini::load_from_file(&profile).context(IniError)?;
+        let conf = Ini::load_from_file(&profile)?;
         let section = match section {
             Some(s) => s,
             None => String::from("default")
         };
         let data1 = match conf.section(Some(section.clone())) {
             Some(d) => Ok(d),
-            None => Err(Error::AwsMissingSection {section: section.clone(), profile: profile.clone()})
+            None => Err(err("Missing aws section"))
         };
         let data2 = match conf.section(Some(section.clone())) {
             Some(d) => Ok(d),
-            None => Err(Error::AwsMissingSection {section, profile: profile.clone()})
+            None => Err(err("Missing aws section"))
         };
         let access_key = match data1?.get("aws_access_key_id") {
             Some(x) => Ok(x.to_owned()),
-            None => Err(Error::AwsConfigError {part: "aws_access_key_id".to_string(), profile: profile.clone()})
+            None => Err(err("Missing aws section"))
         };
         let secret_key = match data2?.get("aws_secret_access_key") {
             Some(x) => Ok(x.to_owned()),
-            None => Err(Error::AwsConfigError {part: "aws_secret_access_key".to_string(), profile})
+            None => Err(err("Missing aws section"))
         };
         Ok(Credentials { access_key: access_key?.to_owned(), secret_key: secret_key?.to_owned(), token: None, _private: () })
     }

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,0 +1,49 @@
+use std;
+use serde_xml;
+use reqwest;
+use core::fmt;
+use std::error::Error;
+
+macro_rules! impl_from {
+    ($t: ty) => {
+        impl From<$t> for S3Error {
+            fn from(e: $t) -> S3Error {
+                S3Error { src: Some(String::from(format!("{}",e))) }
+            }
+        }
+    }
+}
+
+impl_from!(serde_xml::Error);
+impl_from!(reqwest::Error);
+impl_from!(reqwest::header::InvalidHeaderName);
+impl_from!(reqwest::header::InvalidHeaderValue);
+impl_from!(std::env::VarError);
+impl_from!(ini::ini::Error);
+
+#[derive(Debug)]
+pub struct S3Error {
+    pub src: Option<String>
+}
+
+pub fn err(e: &str) -> S3Error {
+    S3Error {src: Some(String::from(e))}
+}
+
+impl fmt::Display for S3Error {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        match self.src.as_ref() {
+            Some(err) => write!(f, "{}", err),
+            None => write!(f, "An unknown error has occured!")
+        }
+
+    }
+}
+
+impl Error for S3Error {
+    fn source(&self) -> Option<&(dyn Error + 'static)> {
+        None
+    }
+}
+
+pub type S3Result<T, E = S3Error> = std::result::Result<T, E>;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -12,7 +12,6 @@ extern crate url;
 extern crate ini;
 extern crate dirs;
 extern crate futures;
-extern crate snafu;
 extern crate core;
 
 pub mod bucket;
@@ -23,6 +22,8 @@ pub mod request;
 pub mod serde_types;
 pub mod signing;
 pub mod deserializer;
+#[macro_use]
+pub mod error;
 
 const LONG_DATE: &str = "%Y%m%dT%H%M%SZ";
 const EMPTY_PAYLOAD_SHA: &str = "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855";

--- a/src/region.rs
+++ b/src/region.rs
@@ -1,19 +1,6 @@
 use std::fmt;
 use std::str::{self, FromStr};
-use snafu::Snafu;
-
-#[derive(Debug, Snafu)]
-pub enum Error {
-    XmlError,
-    RequestError {
-        source: ::request::Error
-    },
-    ParseError {
-        source: std::string::ParseError
-    }
-}
-
-type S3Result<T, E = Error> = std::result::Result<T, E>;
+use error::{S3Result, S3Error};
 
 /// AWS S3 [region identifier](https://docs.aws.amazon.com/general/latest/gr/rande.html#s3_region),
 /// passing in custom values is also possible, in that case it is up to you to pass a valid endpoint,
@@ -115,7 +102,7 @@ impl fmt::Display for Region {
 }
 
 impl FromStr for Region {
-    type Err = Error;
+    type Err = S3Error;
 
     fn from_str(s: &str) -> S3Result<Self> {
         use self::Region::*;
@@ -179,7 +166,7 @@ impl Region {
 
     pub fn scheme(&self) -> String {
         match *self {
-            Region::Custom{ region: _, ref endpoint } => {
+            Region::Custom{ ref endpoint, ..} => {
                 match endpoint.find("://") {
                     Some(pos) => endpoint[..pos].to_string(),
                     None => "https".to_string()
@@ -191,7 +178,7 @@ impl Region {
 
     pub fn host(&self) -> String {
         match *self {
-            Region::Custom{ region: _, ref endpoint } => {
+            Region::Custom{ ref endpoint, ..} => {
                 match endpoint.find("://") {
                     Some(pos) => endpoint[pos + 3..].to_string(),
                     None => endpoint.to_string()

--- a/src/request.rs
+++ b/src/request.rs
@@ -108,13 +108,13 @@ impl<'a> Request<'a> {
             url.query_pairs_mut().append_pair(key, value);
         }
 
-        if let Command::ListBucket { prefix, delimiter, continuation_token } = self.command {
+        if let Command::ListBucket { prefix, delimiter, continuation_token } = &self.command {
             let mut query_pairs = url.query_pairs_mut();
             delimiter.map(|d| query_pairs.append_pair("delimiter", d));
             query_pairs.append_pair("prefix", prefix);
             query_pairs.append_pair("list-type", "2");
             if let Some(token) = continuation_token {
-                query_pairs.append_pair("continuation-token", token);
+                query_pairs.append_pair("continuation-token", &token);
             }
         }
 

--- a/src/signing.rs
+++ b/src/signing.rs
@@ -20,7 +20,7 @@ pub fn uri_encode(string: &str, encode_slash: bool) -> String {
     let mut result = String::with_capacity(string.len() * 2);
     for c in string.chars() {
         match c {
-            'a'...'z' | 'A'...'Z' | '0'...'9' | '_' | '-' | '~' | '.' => result.push(c),
+            'a'..='z' | 'A'..='Z' | '0'..='9' | '_' | '-' | '~' | '.' => result.push(c),
             '/' if encode_slash => result.push_str("%2F"),
             '/' if !encode_slash => result.push('/'),
             _ => {


### PR DESCRIPTION
Closes #47. 

Adds async version of the `list` bucket method (`list_all_async`), renames `list` to `list_all`. Also adds `list_page` and `list_page_async` `Bucket` methods. Simplifies returned futures so that only a top level future remains, making usage much more ergonomic.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/durch/rust-s3/48)
<!-- Reviewable:end -->
