### PR TITLE
Fix to avoid unintentional fails

### DIFF
--- a/src/credentials.rs
+++ b/src/credentials.rs
@@ -154,12 +154,12 @@ impl Credentials {
 
     fn is_ec2() -> bool {
         if let Ok(uuid) = std::fs::read_to_string("/sys/hypervisor/uuid") {
-            if &uuid[..3] == "ec2" {
+            if uuid.len() >= 3 && &uuid[..3] == "ec2" {
                 return true;
             }
         }
         if let Ok(uuid) = std::fs::read_to_string("/sys/class/dmi/id/board_vendor") {
-            if &uuid[..10] == "Amazon EC2" {
+            if uuid.len() >= 10 && &uuid[..10] == "Amazon EC2" {
                 return true;
             }
         }


### PR DESCRIPTION
Currently, `rust-s3` reads `/sys/hypervisor/uuid` to determine whether the instance is EC2 or not. But some EC2 instances don't have `/sys/hypervisor/uuid`, but have `/sys/class/dmi/id/board_vendor`. This change will enable `rust-s3` to run also in the latter type EC2 instances.

Reference:
https://github.com/scylladb/scylla/commit/2a4ba883c8e9c3351ff69064bb4d09954ff001c4#diff-23bb822fd3271daf086e185150f31517

Closes #67

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/durch/rust-s3/68)
<!-- Reviewable:end -->
