### PR TITLE
Correct bucket endpoint url

### DIFF
--- a/src/bucket.rs
+++ b/src/bucket.rs
@@ -540,7 +540,7 @@ impl Bucket {
     }
 
     pub fn self_host(&self) -> String {
-        format!("{}.s3.amazonaws.com", self.name)
+        format!("{}.{}", self.name, self.region.host())
     }
 
     pub fn scheme(&self) -> String {


### PR DESCRIPTION
The old url was fixed to the generic amazon s3 endpoint. This is
naturally not applicable for anyone using different regions (or s3
providers).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/durch/rust-s3/69)
<!-- Reviewable:end -->
