### PR TITLE
Fix continue logic of list_buckets

### DIFF
--- a/s3/src/bucket.rs
+++ b/s3/src/bucket.rs
@@ -814,6 +814,9 @@ impl Bucket {
         let mut result = self.list_page_blocking(prefix.clone(), delimiter.clone(), None)?;
         loop {
             results.push(result.clone());
+            if !result.0.is_truncated {
+                break
+            }
             match result.0.next_continuation_token {
                 Some(token) => {
                     result =


### PR DESCRIPTION
Hi, 

> NextContinuationToken is sent when isTruncated is true, which means there are more keys in the bucket that can be listed. 

According to [S3 docs](https://docs.aws.amazon.com/AmazonS3/latest/API/API_ListObjectsV2.html#AmazonS3-ListObjectsV2-response-NextContinuationToken), it should ensure `isTruncated` to be `true` before using `NextContinuationToken`, or it will cause forever loop (in my case).

@durch Please review. 