### PR TITLE
handle S3 URLs that are encoded differently in percent-encoding and AWS

### DIFF
--- a/s3/Cargo.toml
+++ b/s3/Cargo.toml
@@ -38,6 +38,7 @@ aws-region = "0.21.0"
 aws-creds = "0.22.1"
 log = "0.4.8"
 once_cell = "1.3.1"
+percent-encoding = "2.1.0"
 
 [features]
 no-verify-ssl = []


### PR DESCRIPTION
the Url crate does not encode (for example) parentheses, but AWS
wants them for the purposes of signing. This change decodes
the Url and then re-encodes it with AWS's idea of canonical
percent-encoding.