### PR TITLE
Make openssl optional

### DIFF
--- a/aws-creds/Cargo.toml
+++ b/aws-creds/Cargo.toml
@@ -26,6 +26,6 @@ serde_derive = "1"
 
 
 [features]
-default = ["rustls-tls"]
+default = ["native-tls"]
 native-tls = ["attohttpc/tls"]
 rustls-tls = ["attohttpc/tls-rustls"]

--- a/aws-creds/Cargo.toml
+++ b/aws-creds/Cargo.toml
@@ -18,8 +18,14 @@ path = "src/lib.rs"
 simpl = "0.1.0"
 dirs = "3"
 rust-ini = "0.15"
-attohttpc = {version = "0.15", features = ["json"]}
+attohttpc = {version = "0.15", default-features  = false, features = ["json"]}
 url = "2"
 serde-xml-rs = "0.4"
 serde = "1"
 serde_derive = "1"
+
+
+[features]
+default = ["rustls-tls"]
+native-tls = ["attohttpc/tls"]
+rustls-tls = ["attohttpc/tls-rustls"]

--- a/s3/Cargo.toml
+++ b/s3/Cargo.toml
@@ -35,7 +35,7 @@ tokio = {version="0.2", features=["macros", "io-util", "stream"]}
 rand = "0.7"
 simpl = "0.1.0"
 aws-region = "0.22"
-aws-creds = "0.24"
+aws-creds = {version = "0.24", default-features = false}
 log = "0.4"
 percent-encoding = "2"
 async-std = "1"
@@ -47,8 +47,8 @@ cfg-if = "0.1"
 default = ["native-tls"]
 no-verify-ssl = []
 fail-on-err = []
-native-tls = ["reqwest/native-tls"]
-rustls-tls = ["reqwest/rustls-tls"]
+native-tls = ["reqwest/native-tls", "aws-creds/native-tls"]
+rustls-tls = ["reqwest/rustls-tls", "aws-creds/rustls-tls"]
 
 [dev-dependencies]
 tokio = {version="0.2", features=["fs"]}

--- a/s3/Cargo.toml
+++ b/s3/Cargo.toml
@@ -23,7 +23,7 @@ base64 = "0.12"
 chrono = "0.4"
 hex = "0.4"
 hmac = "0.9"
-reqwest = {version = "0.10", features = ["json", "stream"]}
+reqwest = {version = "0.10", default-features = false, features = ["json", "stream"]}
 serde_derive = "1"
 serde = "1"
 serde-xml-rs = "0.4"
@@ -40,6 +40,7 @@ log = "0.4"
 percent-encoding = "2"
 async-std = "1"
 http = "0.2"
+cfg-if = "0.1"
 
 
 [features]

--- a/s3/src/request.rs
+++ b/s3/src/request.rs
@@ -496,9 +496,9 @@ impl<'a> Request<'a> {
             let client = Client::builder().danger_accept_invalid_certs(true);
 
                 cfg_if::cfg_if! {
-                    if #[cfg(feature = "no-verify-ssl")]
+                    if #[cfg(feature = "native-tls")]
                     {
-                        client.danger_accept_invalid_hostnames(true);
+                        let client = client.danger_accept_invalid_hostnames(true);
                     }
 
                 }

--- a/s3/src/request.rs
+++ b/s3/src/request.rs
@@ -493,10 +493,17 @@ impl<'a> Request<'a> {
         };
 
         let client = if cfg!(feature = "no-verify-ssl") {
-            Client::builder()
-                .danger_accept_invalid_certs(true)
-                .danger_accept_invalid_hostnames(true)
-                .build()
+            let client = Client::builder().danger_accept_invalid_certs(true);
+
+                cfg_if::cfg_if! {
+                    if #[cfg(feature = "no-verify-ssl")]
+                    {
+                        client.danger_accept_invalid_hostnames(true);
+                    }
+
+                }
+
+                client.build()
                 .expect("Could not build dangerous client!")
         } else {
             Client::new()


### PR DESCRIPTION
This removes the need for openssl in `reqwest` and `attohttpc` dependencies, currently it is not possible to compile without openssl.

Add the following to Cargo.toml in your project:

```toml
rust-s3 = {version = "0.24", default-features = false, features = ["rustls-tls"]}
aws-creds = {version = "0.24", default-features = false, features = ["rustls-tls"]}

[patch.crates-io]
aws-creds = { git = "https://github.com/koplas/rust-s3/", branch="rustls"}
rust-s3 = { git = "https://github.com/koplas/rust-s3/", branch="rustls"}
```

Check for openssl with:

`cargo tree | grep openssl`