### PR TITLE
BucketCreate and BucketDelete Commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,10 +27,17 @@ a `PUT` presigned URL, meaning they can upload to a specific key in S3 for the d
 
 `Bucket` struct provides constructors for `path-style` paths, `subdomain` style is the default. `Bucket` exposes methods for configuring and accessing `path-style` configuration.
 
+#### Buckets
+
+|          |                                                                               |
+|----------|-------------------------------------------------------------------------------|
+| `create` | [async](https://docs.rs/rust-s3/s3/bucket/struct.Bucket.html#method.create)   |
+| `delete` | [async]((https://docs.rs/rust-s3/s3/bucket/struct.Bucket.html#method.delete)) |
+
 #### Presign
 
-|       |                                                                                                |
-|-------|------------------------------------------------------------------------------------------------|
+|       |                                                                                        |
+|-------|----------------------------------------------------------------------------------------|
 | `PUT` | [presign_put](https://docs.rs/rust-s3/s3/bucket/struct.Bucket.html#method.presign_put) |
 | `GET` | [presign_get](https://docs.rs/rust-s3/s3/bucket/struct.Bucket.html#method.presign_get) |
 
@@ -39,8 +46,8 @@ a `PUT` presigned URL, meaning they can upload to a specific key in S3 for the d
 There are a few different options for getting an object. `sync` and `async` methods are generic over `std::io::Write`,
 while `tokio` methods are generic over `tokio::io::AsyncWriteExt`.
 
-|         |                                                                                                                              |
-|---------|------------------------------------------------------------------------------------------------------------------------------|
+|         |                                                                                                                      |
+|---------|----------------------------------------------------------------------------------------------------------------------|
 | `async` | [get_object](https://docs.rs/rust-s3/s3/bucket/struct.Bucket.html#method.get_object)                                 |
 | `async` | [get_object_stream](https://docs.rs/rust-s3/s3/bucket/struct.Bucket.html#method.get_object_stream)                   |
 | `sync`  | [get_object_blocking](https://docs.rs/rust-s3/s3/bucket/struct.Bucket.html#method.get_object_blocking)               |
@@ -51,41 +58,41 @@ while `tokio` methods are generic over `tokio::io::AsyncWriteExt`.
 
 Each `GET` method has a `PUT` companion `sync` and `async` methods are generic over `std::io::Read`. `async` `stream` methods are generic over `futures::io::AsyncReadExt`, while `tokio` methods are generic over `tokio::io::AsyncReadExt`.
 
-|         |                                                                                                                                                    |
-|---------|----------------------------------------------------------------------------------------------------------------------------------------------------|
-| `async` | [put_object](https://docs.rs/rust-s3/s3/bucket/struct.Bucket.html#method.put_object)                                                       |
-| `async` | [put_object_with_content_type](https://docs.rs/rust-s3/s3/bucket/struct.Bucket.html#method.put_object_with_content_type)                   |
-| `async` | [put_object_stream](https://docs.rs/rust-s3/s3/bucket/struct.Bucket.html#method.put_object_stream)                                         |
-| `sync`  | [put_object_blocking](https://docs.rs/rust-s3/s3/bucket/struct.Bucket.html#method.put_object_blocking)                                     |
-| `sync`  | [put_object_with_content_type_blocking](https://docs.rs/rust-s3/s3/bucket/struct.Bucket.html#method.put_object_with_content_type_blocking) |
-| `sync`  | [put_object_stream_blocking](https://docs.rs/rust-s3/s3/bucket/struct.Bucket.html#method.put_object_stream_blocking)                       |
-| `tokio` | :x: [#110](https://github.com/durch/rust-s3/issues) - [tokio_put_object_stream](https://docs.rs/rust-s3/s3/bucket/struct.Bucket.html#method.tokio_put_object_stream)                             |
+|         |                                                                                                                                                                      |
+|---------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `async` | [put_object](https://docs.rs/rust-s3/s3/bucket/struct.Bucket.html#method.put_object)                                                                                 |
+| `async` | [put_object_with_content_type](https://docs.rs/rust-s3/s3/bucket/struct.Bucket.html#method.put_object_with_content_type)                                             |
+| `async` | [put_object_stream](https://docs.rs/rust-s3/s3/bucket/struct.Bucket.html#method.put_object_stream)                                                                   |
+| `sync`  | [put_object_blocking](https://docs.rs/rust-s3/s3/bucket/struct.Bucket.html#method.put_object_blocking)                                                               |
+| `sync`  | [put_object_with_content_type_blocking](https://docs.rs/rust-s3/s3/bucket/struct.Bucket.html#method.put_object_with_content_type_blocking)                           |
+| `sync`  | [put_object_stream_blocking](https://docs.rs/rust-s3/s3/bucket/struct.Bucket.html#method.put_object_stream_blocking)                                                 |
+| `tokio` | :x: [#110](https://github.com/durch/rust-s3/issues) - [tokio_put_object_stream](https://docs.rs/rust-s3/s3/bucket/struct.Bucket.html#method.tokio_put_object_stream) |
 
 #### List
 
-|         |                                                                                                    |
-|---------|----------------------------------------------------------------------------------------------------|
+|         |                                                                                            |
+|---------|--------------------------------------------------------------------------------------------|
 | `async` | [list](https://docs.rs/rust-s3/s3/bucket/struct.Bucket.html#method.list)                   |
 | `sync`  | [list_blocking](https://docs.rs/rust-s3/s3/bucket/struct.Bucket.html#method.list_blocking) |
 
 #### DELETE
 
-|         |                                                                                                                      |
-|---------|----------------------------------------------------------------------------------------------------------------------|
+|         |                                                                                                              |
+|---------|--------------------------------------------------------------------------------------------------------------|
 | `async` | [delete_object](https://docs.rs/rust-s3/s3/bucket/struct.Bucket.html#method.delete_object)                   |
 | `sync`  | [delete_object_blocking](https://docs.rs/rust-s3/s3/bucket/struct.Bucket.html#method.delete_object_blocking) |
 
 #### Location
 
-|         |                                                                                                            |
-|---------|------------------------------------------------------------------------------------------------------------|
+|         |                                                                                                    |
+|---------|----------------------------------------------------------------------------------------------------|
 | `async` | [location](https://docs.rs/rust-s3/s3/bucket/struct.Bucket.html#method.location)                   |
 | `sync`  | [location_blocking](https://docs.rs/rust-s3/s3/bucket/struct.Bucket.html#method.location_blocking) |
 
 #### Tagging
 
-|         |                                                                                                                                |
-|---------|--------------------------------------------------------------------------------------------------------------------------------|
+|         |                                                                                                                        |
+|---------|------------------------------------------------------------------------------------------------------------------------|
 | `async` | [put_object_tagging](https://docs.rs/rust-s3/s3/bucket/struct.Bucket.html#method.put_object_tagging)                   |
 | `sync`  | [put_object_tagging_blocking](https://docs.rs/rust-s3/s3/bucket/struct.Bucket.html#method.put_object_tagging_blocking) |
 | `async` | [get_object_tagging](https://docs.rs/rust-s3/s3/bucket/struct.Bucket.html#method.get_object_tagging)                   |

--- a/s3/Cargo.toml
+++ b/s3/Cargo.toml
@@ -39,7 +39,8 @@ log = "0.4"
 percent-encoding = "2"
 async-std = "1"
 http = "0.2"
-cfg-if = "0.1"
+cfg-if = "1"
+uuid = "0.8"
 
 
 [features]
@@ -51,3 +52,4 @@ rustls-tls = ["reqwest/rustls-tls", "aws-creds/rustls-tls"]
 
 [dev-dependencies]
 tokio = {version="0.2", features=["fs"]}
+uuid = { version="0.8", features=["v4"]}

--- a/s3/Cargo.toml
+++ b/s3/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rust-s3"
-version = "0.26.2-beta0"
+version = "0.26.2"
 authors = ["Drazen Urch"]
 description = "Tiny Rust library for working with Amazon S3 and compatible object storage APIs"
 repository = "https://github.com/durch/rust-s3"

--- a/s3/Cargo.toml
+++ b/s3/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rust-s3"
-version = "0.26.1"
+version = "0.26.2-beta0"
 authors = ["Drazen Urch"]
 description = "Tiny Rust library for working with Amazon S3 and compatible object storage APIs"
 repository = "https://github.com/durch/rust-s3"

--- a/s3/src/bucket.rs
+++ b/s3/src/bucket.rs
@@ -136,6 +136,10 @@ impl Bucket {
     ///
     /// #[tokio::main]
     /// async fn main() -> Result<(), S3Error> {
+    ///     # // Fake  credentials so we don't access user's real credentials in tests
+    ///     # use std::env;
+    ///     # env::set_var("AWS_ACCESS_KEY_ID", "AKIAIOSFODNN7EXAMPLE");
+    ///     # env::set_var("AWS_SECRET_ACCESS_KEY", "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY");
     ///     let bucket_name = "rust-s3-test";
     ///     let region = "us-east-1".parse().unwrap();
     ///     let credentials = Credentials::default().unwrap();

--- a/s3/src/bucket.rs
+++ b/s3/src/bucket.rs
@@ -129,17 +129,13 @@ impl Bucket {
     /// Create a new `Bucket` and instantiate it
     ///
     /// # Example
-    /// ```
+    /// ```rust,no_run
     /// use s3::{Bucket, BucketConfiguration};
     /// use s3::creds::Credentials;
     /// use s3::S3Error;
     ///
     /// #[tokio::main]
     /// async fn main() -> Result<(), S3Error> {
-    ///     // Fake  credentials so we don't access user's real credentials in tests
-    ///     use std::env;
-    ///     env::set_var("AWS_ACCESS_KEY_ID", "AKIAIOSFODNN7EXAMPLE");
-    ///     env::set_var("AWS_SECRET_ACCESS_KEY", "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY");
     ///     let bucket_name = "rust-s3-test";
     ///     let region = "us-east-1".parse().unwrap();
     ///     let credentials = Credentials::default().unwrap();
@@ -171,17 +167,13 @@ impl Bucket {
     /// Delete existing `Bucket`
     ///
     /// # Example
-    /// ```
+    /// ```rust,no_run
     /// use s3::Bucket;
     /// use s3::creds::Credentials;
     /// use s3::S3Error;
     ///
     /// #[tokio::main]
     /// async fn main() -> Result<(), S3Error> {
-    ///     // Fake  credentials so we don't access user's real credentials in tests
-    ///     use std::env;
-    ///     env::set_var("AWS_ACCESS_KEY_ID", "AKIAIOSFODNN7EXAMPLE");
-    ///     env::set_var("AWS_SECRET_ACCESS_KEY", "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY");
     ///     let bucket_name = "rust-s3-test";
     ///     let region = "us-east-1".parse().unwrap();
     ///     let credentials = Credentials::default().unwrap();
@@ -202,14 +194,11 @@ impl Bucket {
     /// Instantiate an existing `Bucket`.
     ///
     /// # Example
-    /// ```
+    /// ```rust,no_run
     /// use s3::bucket::Bucket;
     /// use s3::creds::Credentials;
     ///
     /// // Fake  credentials so we don't access user's real credentials in tests
-    /// use std::env;
-    /// env::set_var("AWS_ACCESS_KEY_ID", "AKIAIOSFODNN7EXAMPLE");
-    /// env::set_var("AWS_SECRET_ACCESS_KEY", "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY");
     /// let bucket_name = "rust-s3-test";
     /// let region = "us-east-1".parse().unwrap();
     /// let credentials = Credentials::default().unwrap();

--- a/s3/src/bucket.rs
+++ b/s3/src/bucket.rs
@@ -136,10 +136,10 @@ impl Bucket {
     ///
     /// #[tokio::main]
     /// async fn main() -> Result<(), S3Error> {
-    ///     # // Fake  credentials so we don't access user's real credentials in tests
-    ///     # use std::env;
-    ///     # env::set_var("AWS_ACCESS_KEY_ID", "AKIAIOSFODNN7EXAMPLE");
-    ///     # env::set_var("AWS_SECRET_ACCESS_KEY", "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY");
+    ///     // Fake  credentials so we don't access user's real credentials in tests
+    ///     use std::env;
+    ///     env::set_var("AWS_ACCESS_KEY_ID", "AKIAIOSFODNN7EXAMPLE");
+    ///     env::set_var("AWS_SECRET_ACCESS_KEY", "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY");
     ///     let bucket_name = "rust-s3-test";
     ///     let region = "us-east-1".parse().unwrap();
     ///     let credentials = Credentials::default().unwrap();
@@ -178,6 +178,10 @@ impl Bucket {
     ///
     /// #[tokio::main]
     /// async fn main() -> Result<(), S3Error> {
+    ///     // Fake  credentials so we don't access user's real credentials in tests
+    ///     use std::env;
+    ///     env::set_var("AWS_ACCESS_KEY_ID", "AKIAIOSFODNN7EXAMPLE");
+    ///     env::set_var("AWS_SECRET_ACCESS_KEY", "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY");
     ///     let bucket_name = "rust-s3-test";
     ///     let region = "us-east-1".parse().unwrap();
     ///     let credentials = Credentials::default().unwrap();
@@ -202,6 +206,10 @@ impl Bucket {
     /// use s3::bucket::Bucket;
     /// use s3::creds::Credentials;
     ///
+    /// // Fake  credentials so we don't access user's real credentials in tests
+    /// use std::env;
+    /// env::set_var("AWS_ACCESS_KEY_ID", "AKIAIOSFODNN7EXAMPLE");
+    /// env::set_var("AWS_SECRET_ACCESS_KEY", "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY");
     /// let bucket_name = "rust-s3-test";
     /// let region = "us-east-1".parse().unwrap();
     /// let credentials = Credentials::default().unwrap();

--- a/s3/src/bucket_ops.rs
+++ b/s3/src/bucket_ops.rs
@@ -1,0 +1,155 @@
+use crate::{Result, Bucket, Region};
+use reqwest::header::HeaderMap;
+
+/// [AWS Documentation](https://docs.aws.amazon.com/AmazonS3/latest/dev/acl-overview.html#CannedACL)
+#[allow(dead_code)]
+#[derive(Clone, Debug)]
+enum CannedBucketAcl {
+    Private,
+    PublicRead,
+    PublicReadWrite,
+    AuthenticatedRead,
+}
+
+use std::fmt;
+
+impl fmt::Display for CannedBucketAcl {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            CannedBucketAcl::Private => write!(f, "private"),
+            CannedBucketAcl::PublicRead => write!(f, "public-read"),
+            CannedBucketAcl::PublicReadWrite => write!(f, "public-read-write"),
+            CannedBucketAcl::AuthenticatedRead => write!(f, "authenticated-read"),
+        }
+    }
+}
+
+/// [AWS Documentation](https://docs.aws.amazon.com/AmazonS3/latest/dev/acl-overview.html)
+#[allow(dead_code)]
+#[derive(Clone, Debug)]
+enum BucketAcl {
+    Id { id: String },
+    Uri { uri: String },
+    Email { email: String },
+}
+
+impl fmt::Display for BucketAcl {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            BucketAcl::Id { id } => write!(f, "id=\"{}\"", id),
+            BucketAcl::Uri { uri } => write!(f, "uri=\"{}\"", uri),
+            BucketAcl::Email { email } => write!(f, "email=\"{}\"", email),
+        }
+    }
+}
+
+#[derive(Clone, Debug)]
+pub struct BucketConfiguration {
+    acl: CannedBucketAcl,
+    object_lock_enabled: bool,
+    grant_full_control: Option<Vec<BucketAcl>>,
+    grant_read: Option<Vec<BucketAcl>>,
+    grant_read_acp: Option<Vec<BucketAcl>>,
+    grant_write: Option<Vec<BucketAcl>>,
+    grant_write_acp: Option<Vec<BucketAcl>>,
+    location_constraint: Option<Region>,
+}
+
+impl Default for BucketConfiguration {
+    fn default() -> Self {
+        BucketConfiguration::private()
+    }
+}
+
+fn acl_list(acl: &[BucketAcl]) -> String {
+    acl.iter()
+        .map(|x| x.to_string())
+        .collect::<Vec<String>>()
+        .join(",")
+}
+
+impl BucketConfiguration {
+    pub fn public() -> Self {
+        BucketConfiguration {
+            acl: CannedBucketAcl::PublicReadWrite,
+            object_lock_enabled: false,
+            grant_full_control: None,
+            grant_read: None,
+            grant_read_acp: None,
+            grant_write: None,
+            grant_write_acp: None,
+            location_constraint: None,
+        }
+    }
+
+    pub fn private() -> Self {
+        BucketConfiguration {
+            acl: CannedBucketAcl::Private,
+            object_lock_enabled: false,
+            grant_full_control: None,
+            grant_read: None,
+            grant_read_acp: None,
+            grant_write: None,
+            grant_write_acp: None,
+            location_constraint: None,
+        }
+    }
+
+    pub fn set_region(&mut self, region: Region) {
+        self.set_location_constraint(region)
+    }
+
+    pub fn set_location_constraint(&mut self, region: Region) {
+        self.location_constraint = Some(region)
+    }
+
+    pub fn location_constraint_payload(&self) -> Option<String> {
+        if let Some(ref location_constraint) = self.location_constraint {
+            if location_constraint == &Region::UsEast1 {
+                return None
+            }
+            Some(format!(
+                "<CreateBucketConfiguration><LocationConstraint>{}</LocationConstraint></CreateBucketConfiguration>",
+                location_constraint.to_string()
+            ))
+        } else {
+            None
+        }
+    }
+
+    pub fn add_headers(&self, headers: &mut HeaderMap) -> Result<()> {
+        headers.insert("x-amz-acl", self.acl.to_string().parse()?);
+        if self.object_lock_enabled {
+            headers.insert("x-amz-bucket-object-lock-enabled", "Enabled".parse()?);
+        }
+        if let Some(ref value) = self.grant_full_control {
+            headers.insert("x-amz-grant-full-control", acl_list(value).parse()?);
+        }
+        if let Some(ref value) = self.grant_read {
+            headers.insert("x-amz-grant-read", acl_list(value).parse()?);
+        }
+        if let Some(ref value) = self.grant_read_acp {
+            headers.insert("x-amz-grant-read-acp", acl_list(value).parse()?);
+        }
+        if let Some(ref value) = self.grant_write {
+            headers.insert("x-amz-grant-write", acl_list(value).parse()?);
+        }
+        if let Some(ref value) = self.grant_write_acp {
+            headers.insert("x-amz-grant-write-acp", acl_list(value).parse()?);
+        }
+        Ok(())
+    }
+}
+
+#[allow(dead_code)]
+pub struct CreateBucketResponse {
+    pub bucket: Bucket,
+    pub response_text: String,
+    pub response_code: u16
+}
+
+impl CreateBucketResponse {
+    pub fn success(&self) -> bool {
+        self.response_code == 200
+    }
+}

--- a/s3/src/command.rs
+++ b/s3/src/command.rs
@@ -1,4 +1,5 @@
 use crate::serde_types::CompleteMultipartUploadData;
+use crate::bucket_ops::BucketConfiguration;
 use reqwest::Method;
 use reqwest::header::HeaderMap;
 
@@ -44,6 +45,8 @@ pub enum Command<'a> {
         upload_id: &'a str,
         data: CompleteMultipartUploadData,
     },
+    CreateBucket { config: BucketConfiguration },
+    DeleteBucket
 }
 
 impl<'a> Command<'a> {
@@ -57,10 +60,12 @@ impl<'a> Command<'a> {
             Command::PutObject { .. }
             | Command::PutObjectTagging { .. }
             | Command::PresignPut { .. }
-            | Command::UploadPart { .. } => Method::PUT,
+            | Command::UploadPart { .. }
+            | Command::CreateBucket { .. } => Method::PUT,
             Command::DeleteObject
             | Command::DeleteObjectTagging
-            | Command::AbortMultipartUpload { .. } => Method::DELETE,
+            | Command::AbortMultipartUpload { .. } 
+            | Command::DeleteBucket => Method::DELETE,
             Command::InitiateMultipartUpload | Command::CompleteMultipartUpload { .. } => {
                 Method::POST
             }

--- a/s3/src/lib.rs
+++ b/s3/src/lib.rs
@@ -8,12 +8,17 @@ use serde_xml_rs as serde_xml;
 pub use awscreds as creds;
 pub use awsregion as region;
 
+pub use bucket::Bucket;
+pub use bucket_ops::BucketConfiguration;
+pub use region::Region;
+
 pub mod bucket;
 pub mod command;
 pub mod deserializer;
 pub mod request;
 pub mod serde_types;
 pub mod signing;
+pub mod bucket_ops;
 
 pub mod utils;
 

--- a/s3/src/request.rs
+++ b/s3/src/request.rs
@@ -96,10 +96,7 @@ impl<'a> Request<'a> {
     fn url(&self, encode_path: bool) -> Url {
         let mut url_str = self.bucket.url();
 
-        match self.command {
-            Command::CreateBucket { .. } => return Url::parse(&url_str).unwrap(),
-            _ => {}
-        }
+        if let Command::CreateBucket { .. } = self.command { return Url::parse(&url_str).unwrap() }
 
         let path = if self.path.starts_with('/') {
             &self.path[1..]


### PR DESCRIPTION
Closes #127 

Adds `BucketCreate` and `BucketDelete` commands, as well as bucket ops scaffolding, available on crates.io as `0.26.2-beta0`