### PR TITLE
Add HeadObject command

### DIFF
--- a/s3/src/bucket.rs
+++ b/s3/src/bucket.rs
@@ -624,7 +624,23 @@ impl Bucket {
     }
 
     /// Head object from S3, async.
+    /// # Example:
     ///
+    /// ```rust,no_run
+    /// use s3::bucket::Bucket;
+    /// use s3::creds::Credentials;
+    /// use s3::S3Error;
+    /// #[tokio::main]
+    /// async fn main() -> Result<(), S3Error> {
+    ///     let bucket_name = &"rust-s3-test";
+    ///     let region = "us-east-1".parse()?;
+    ///     let credentials = Credentials::default()?;
+    ///     let bucket = Bucket::new(bucket_name, region, credentials)?;
+    ///     let (head_object_result, code) = bucket.head_object("/test.png").await.unwrap();
+    ///     assert_eq!(head_object_result.content_type.unwrap() , "image/png".to_owned());
+    ///     Ok(())
+    /// }
+    /// ```
     pub async fn head_object<S: AsRef<str>>(&self, path: S) -> Result<(HeadObjectResult, u16)> {
         let command = Command::HeadObject;
         let request = Request::new(self, path.as_ref(), command);
@@ -634,7 +650,19 @@ impl Bucket {
     }
 
     /// Head object from S3, blocks.
+    /// # Example:
     ///
+    /// ```rust,no_run
+    /// use s3::bucket::Bucket;
+    /// use s3::creds::Credentials;
+    /// use s3::S3Error;
+    /// let bucket_name = &"rust-s3-test";
+    /// let region = "us-east-1".parse()?;
+    /// let credentials = Credentials::default()?;
+    /// let bucket = Bucket::new(bucket_name, region, credentials)?;
+    /// let (head_object_result, code) = bucket.head_object_blocking("/test.png").unwrap();
+    /// assert_eq!(head_object_result.content_type.unwrap() , "image/png".to_owned());
+    /// ```
     pub fn head_object_blocking<S: AsRef<str>>(&self, path: S) -> Result<(HeadObjectResult, u16)> {
         let mut rt = Runtime::new()?;
         Ok(rt.block_on(self.head_object(path))?)

--- a/s3/src/bucket.rs
+++ b/s3/src/bucket.rs
@@ -1493,11 +1493,11 @@ mod test {
         let (data, code) = bucket.get_object(s3_path).await.unwrap();
         assert_eq!(code, 200);
         // println!("{}", std::str::from_utf8(&data).unwrap());
-		assert_eq!(test, data);
-		let (head_object_result, code) = bucket.head_object(s3_path).await.unwrap();
-		assert_eq!(code, 200);
-		assert_eq!(head_object_result.content_type.unwrap(), "application/octet-stream".to_owned());
-		// println!("{:?}", head_object_result);
+        assert_eq!(test, data);
+        let (head_object_result, code) = bucket.head_object(s3_path).await.unwrap();
+        assert_eq!(code, 200);
+        assert_eq!(head_object_result.content_type.unwrap(), "application/octet-stream".to_owned());
+        // println!("{:?}", head_object_result);
         let (_, code) = bucket.delete_object(s3_path).await.unwrap();
         assert_eq!(code, 204);
     }
@@ -1515,11 +1515,11 @@ mod test {
         let (data, code) = bucket.get_object(s3_path).await.unwrap();
         assert_eq!(code, 200);
         // println!("{}", std::str::from_utf8(&data).unwrap());
-		assert_eq!(test, data);
-		let (head_object_result, code) = bucket.head_object(s3_path).await.unwrap();
-		assert_eq!(code, 200);
-		assert_eq!(head_object_result.content_type.unwrap(), "application/octet-stream".to_owned());
-		// println!("{:?}", head_object_result);
+        assert_eq!(test, data);
+        let (head_object_result, code) = bucket.head_object(s3_path).await.unwrap();
+        assert_eq!(code, 200);
+        assert_eq!(head_object_result.content_type.unwrap(), "application/octet-stream".to_owned());
+        // println!("{:?}", head_object_result);
         let (_, code) = bucket.delete_object(s3_path).await.unwrap();
         assert_eq!(code, 204);
     }
@@ -1537,11 +1537,11 @@ mod test {
         let (data, code) = bucket.get_object(s3_path).await.unwrap();
         assert_eq!(code, 200);
         // println!("{}", std::str::from_utf8(&data).unwrap());
-		assert_eq!(test, data);
-		let (head_object_result, code) = bucket.head_object(s3_path).await.unwrap();
-		assert_eq!(code, 200);
-		assert_eq!(head_object_result.content_type.unwrap(), "application/octet-stream".to_owned());
-		// println!("{:?}", head_object_result);
+        assert_eq!(test, data);
+        let (head_object_result, code) = bucket.head_object(s3_path).await.unwrap();
+        assert_eq!(code, 200);
+        assert_eq!(head_object_result.content_type.unwrap(), "application/octet-stream".to_owned());
+        // println!("{:?}", head_object_result);
         let (_, code) = bucket.delete_object(s3_path).await.unwrap();
         assert_eq!(code, 204);
     }
@@ -1559,11 +1559,11 @@ mod test {
         let (data, code) = bucket.get_object_blocking(s3_path).unwrap();
         assert_eq!(code, 200);
         // println!("{}", std::str::from_utf8(&data).unwrap());
-		assert_eq!(test, data);
-		let (head_object_result, code) = bucket.head_object_blocking(s3_path).unwrap();
-		assert_eq!(code, 200);
-		assert_eq!(head_object_result.content_type.unwrap(), "application/octet-stream".to_owned());
-		// println!("{:?}", head_object_result);
+        assert_eq!(test, data);
+        let (head_object_result, code) = bucket.head_object_blocking(s3_path).unwrap();
+        assert_eq!(code, 200);
+        assert_eq!(head_object_result.content_type.unwrap(), "application/octet-stream".to_owned());
+        // println!("{:?}", head_object_result);
         let (_, code) = bucket.delete_object_blocking(s3_path).unwrap();
         assert_eq!(code, 204);
 	}

--- a/s3/src/bucket.rs
+++ b/s3/src/bucket.rs
@@ -657,9 +657,9 @@ impl Bucket {
     /// use s3::creds::Credentials;
     /// use s3::S3Error;
     /// let bucket_name = &"rust-s3-test";
-    /// let region = "us-east-1".parse()?;
-    /// let credentials = Credentials::default()?;
-    /// let bucket = Bucket::new(bucket_name, region, credentials)?;
+    /// let region = "us-east-1".parse().unwrap();
+    /// let credentials = Credentials::default().unwrap();
+    /// let bucket = Bucket::new(bucket_name, region, credentials).unwrap();
     /// let (head_object_result, code) = bucket.head_object_blocking("/test.png").unwrap();
     /// assert_eq!(head_object_result.content_type.unwrap() , "image/png".to_owned());
     /// ```

--- a/s3/src/bucket.rs
+++ b/s3/src/bucket.rs
@@ -1566,8 +1566,8 @@ mod test {
         // println!("{:?}", head_object_result);
         let (_, code) = bucket.delete_object_blocking(s3_path).unwrap();
         assert_eq!(code, 204);
-	}
-	
+    }
+    
     #[test]
     #[ignore]
     fn test_presign_put() {

--- a/s3/src/bucket.rs
+++ b/s3/src/bucket.rs
@@ -1482,7 +1482,7 @@ mod test {
 
     #[tokio::test]
     #[ignore]
-    async fn test_put_get_delete_object() {
+    async fn test_put_head_get_delete_object() {
         let s3_path = "/test.file";
         let bucket = test_aws_bucket();
         let test: Vec<u8> = object(3072);
@@ -1493,14 +1493,18 @@ mod test {
         let (data, code) = bucket.get_object(s3_path).await.unwrap();
         assert_eq!(code, 200);
         // println!("{}", std::str::from_utf8(&data).unwrap());
-        assert_eq!(test, data);
+		assert_eq!(test, data);
+		let (head_object_result, code) = bucket.head_object(s3_path).await.unwrap();
+		assert_eq!(code, 200);
+		assert_eq!(head_object_result.content_type.unwrap(), "application/octet-stream".to_owned());
+		// println!("{:?}", head_object_result);
         let (_, code) = bucket.delete_object(s3_path).await.unwrap();
         assert_eq!(code, 204);
     }
 
     #[tokio::test]
     #[ignore]
-    async fn gc_test_put_get_delete_object() {
+    async fn gc_test_put_head_get_delete_object() {
         let s3_path = "/test.file";
         let bucket = test_gc_bucket();
         let test: Vec<u8> = object(3072);
@@ -1511,14 +1515,18 @@ mod test {
         let (data, code) = bucket.get_object(s3_path).await.unwrap();
         assert_eq!(code, 200);
         // println!("{}", std::str::from_utf8(&data).unwrap());
-        assert_eq!(test, data);
+		assert_eq!(test, data);
+		let (head_object_result, code) = bucket.head_object(s3_path).await.unwrap();
+		assert_eq!(code, 200);
+		assert_eq!(head_object_result.content_type.unwrap(), "application/octet-stream".to_owned());
+		// println!("{:?}", head_object_result);
         let (_, code) = bucket.delete_object(s3_path).await.unwrap();
         assert_eq!(code, 204);
     }
 
     #[tokio::test]
     #[ignore]
-    async fn wasabi_test_put_get_delete_object() {
+    async fn wasabi_test_put_head_get_delete_object() {
         let s3_path = "/test.file";
         let bucket = test_wasabi_bucket();
         let test: Vec<u8> = object(3072);
@@ -1529,14 +1537,18 @@ mod test {
         let (data, code) = bucket.get_object(s3_path).await.unwrap();
         assert_eq!(code, 200);
         // println!("{}", std::str::from_utf8(&data).unwrap());
-        assert_eq!(test, data);
+		assert_eq!(test, data);
+		let (head_object_result, code) = bucket.head_object(s3_path).await.unwrap();
+		assert_eq!(code, 200);
+		assert_eq!(head_object_result.content_type.unwrap(), "application/octet-stream".to_owned());
+		// println!("{:?}", head_object_result);
         let (_, code) = bucket.delete_object(s3_path).await.unwrap();
         assert_eq!(code, 204);
     }
 
     #[test]
     #[ignore]
-    fn test_put_get_delete_object_blocking() {
+    fn test_put_head_get_delete_object_blocking() {
         let s3_path = "/test_blocking.file";
         let bucket = test_aws_bucket();
         let test: Vec<u8> = object(3072);
@@ -1547,11 +1559,15 @@ mod test {
         let (data, code) = bucket.get_object_blocking(s3_path).unwrap();
         assert_eq!(code, 200);
         // println!("{}", std::str::from_utf8(&data).unwrap());
-        assert_eq!(test, data);
+		assert_eq!(test, data);
+		let (head_object_result, code) = bucket.head_object_blocking(s3_path).unwrap();
+		assert_eq!(code, 200);
+		assert_eq!(head_object_result.content_type.unwrap(), "application/octet-stream".to_owned());
+		// println!("{:?}", head_object_result);
         let (_, code) = bucket.delete_object_blocking(s3_path).unwrap();
         assert_eq!(code, 204);
-    }
-
+	}
+	
     #[test]
     #[ignore]
     fn test_presign_put() {

--- a/s3/src/command.rs
+++ b/s3/src/command.rs
@@ -4,6 +4,7 @@ use reqwest::header::HeaderMap;
 
 #[derive(Clone, Debug)]
 pub enum Command<'a> {
+	HeadObject,
     DeleteObject,
     DeleteObjectTagging,
     GetObject,
@@ -64,6 +65,9 @@ impl<'a> Command<'a> {
             Command::InitiateMultipartUpload | Command::CompleteMultipartUpload { .. } => {
                 Method::POST
             }
+            Command::HeadObject => {
+				Method::HEAD
+			}
         }
     }
 }

--- a/s3/src/command.rs
+++ b/s3/src/command.rs
@@ -4,7 +4,7 @@ use reqwest::header::HeaderMap;
 
 #[derive(Clone, Debug)]
 pub enum Command<'a> {
-	HeadObject,
+    HeadObject,
     DeleteObject,
     DeleteObjectTagging,
     GetObject,
@@ -66,8 +66,8 @@ impl<'a> Command<'a> {
                 Method::POST
             }
             Command::HeadObject => {
-				Method::HEAD
-			}
+                Method::HEAD
+            }
         }
     }
 }

--- a/s3/src/request.rs
+++ b/s3/src/request.rs
@@ -626,9 +626,9 @@ impl<'a> Request<'a> {
         }
 
         Ok(status_code.as_u16())
-	}
-	
-	pub async fn response_header_future(&self) -> Result<(HeaderMap, u16)> {
+    }
+    
+    pub async fn response_header_future(&self) -> Result<(HeaderMap, u16)> {
         let response = self.response_future().await?;
         let status_code = response.status().as_u16();
         let headers = response.headers().clone();

--- a/s3/src/request.rs
+++ b/s3/src/request.rs
@@ -626,6 +626,13 @@ impl<'a> Request<'a> {
         }
 
         Ok(status_code.as_u16())
+	}
+	
+	pub async fn response_header_future(&self) -> Result<(HeaderMap, u16)> {
+        let response = self.response_future().await?;
+        let status_code = response.status().as_u16();
+        let headers = response.headers().clone();
+        Ok((headers, status_code))
     }
 }
 

--- a/s3/src/serde_types.rs
+++ b/s3/src/serde_types.rs
@@ -173,6 +173,66 @@ pub struct CommonPrefix {
     pub prefix: String,
 }
 
+// Taken from https://github.com/rusoto/rusoto
+#[derive(Deserialize, Debug, Default, Clone)]
+pub struct HeadObjectResult {
+    /// <p>Indicates that a range of bytes was specified.</p>
+    pub accept_ranges: Option<String>,
+    /// <p>Specifies caching behavior along the request/reply chain.</p>
+    pub cache_control: Option<String>,
+    /// <p>Specifies presentational information for the object.</p>
+    pub content_disposition: Option<String>,
+    /// <p>Specifies what content encodings have been applied to the object and thus what decoding mechanisms must be applied to obtain the media-type referenced by the Content-Type header field.</p>
+    pub content_encoding: Option<String>,
+    /// <p>The language the content is in.</p>
+    pub content_language: Option<String>,
+    /// <p>Size of the body in bytes.</p>
+    pub content_length: Option<i64>,
+    /// <p>A standard MIME type describing the format of the object data.</p>
+    pub content_type: Option<String>,
+    /// <p>Specifies whether the object retrieved was (true) or was not (false) a Delete Marker. If false, this response header does not appear in the response.</p>
+    pub delete_marker: Option<bool>,
+    /// <p>An ETag is an opaque identifier assigned by a web server to a specific version of a resource found at a URL.</p>
+    pub e_tag: Option<String>,
+    /// <p>If the object expiration is configured (see PUT Bucket lifecycle), the response includes this header. It includes the expiry-date and rule-id key-value pairs providing object expiration information. The value of the rule-id is URL encoded.</p>
+    pub expiration: Option<String>,
+    /// <p>The date and time at which the object is no longer cacheable.</p>
+    pub expires: Option<String>,
+    /// <p>Last modified date of the object</p>
+    pub last_modified: Option<String>,
+    /// <p>A map of metadata to store with the object in S3.</p>
+    pub metadata: Option<::std::collections::HashMap<String, String>>,
+    /// <p>This is set to the number of metadata entries not returned in <code>x-amz-meta</code> headers. This can happen if you create metadata using an API like SOAP that supports more flexible metadata than the REST API. For example, using SOAP, you can create metadata whose values are not legal HTTP headers.</p>
+    pub missing_meta: Option<i64>,
+    /// <p>Specifies whether a legal hold is in effect for this object. This header is only returned if the requester has the <code>s3:GetObjectLegalHold</code> permission. This header is not returned if the specified version of this object has never had a legal hold applied. For more information about S3 Object Lock, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/dev/object-lock.html">Object Lock</a>.</p>
+    pub object_lock_legal_hold_status: Option<String>,
+    /// <p>The Object Lock mode, if any, that's in effect for this object. This header is only returned if the requester has the <code>s3:GetObjectRetention</code> permission. For more information about S3 Object Lock, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/dev/object-lock.html">Object Lock</a>. </p>
+    pub object_lock_mode: Option<String>,
+    /// <p>The date and time when the Object Lock retention period expires. This header is only returned if the requester has the <code>s3:GetObjectRetention</code> permission.</p>
+    pub object_lock_retain_until_date: Option<String>,
+    /// <p>The count of parts this object has.</p>
+    pub parts_count: Option<i64>,
+    /// <p>Amazon S3 can return this header if your request involves a bucket that is either a source or destination in a replication rule.</p> <p>In replication, you have a source bucket on which you configure replication and destination bucket where Amazon S3 stores object replicas. When you request an object (<code>GetObject</code>) or object metadata (<code>HeadObject</code>) from these buckets, Amazon S3 will return the <code>x-amz-replication-status</code> header in the response as follows:</p> <ul> <li> <p>If requesting an object from the source bucket — Amazon S3 will return the <code>x-amz-replication-status</code> header if the object in your request is eligible for replication.</p> <p> For example, suppose that in your replication configuration, you specify object prefix <code>TaxDocs</code> requesting Amazon S3 to replicate objects with key prefix <code>TaxDocs</code>. Any objects you upload with this key name prefix, for example <code>TaxDocs/document1.pdf</code>, are eligible for replication. For any object request with this key name prefix, Amazon S3 will return the <code>x-amz-replication-status</code> header with value PENDING, COMPLETED or FAILED indicating object replication status.</p> </li> <li> <p>If requesting an object from the destination bucket — Amazon S3 will return the <code>x-amz-replication-status</code> header with value REPLICA if the object in your request is a replica that Amazon S3 created.</p> </li> </ul> <p>For more information, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/dev/NotificationHowTo.html">Replication</a>.</p>
+    pub replication_status: Option<String>,
+    pub request_charged: Option<String>,
+    /// <p>If the object is an archived object (an object whose storage class is GLACIER), the response includes this header if either the archive restoration is in progress (see <a>RestoreObject</a> or an archive copy is already restored.</p> <p> If an archive copy is already restored, the header value indicates when Amazon S3 is scheduled to delete the object copy. For example:</p> <p> <code>x-amz-restore: ongoing-request="false", expiry-date="Fri, 23 Dec 2012 00:00:00 GMT"</code> </p> <p>If the object restoration is in progress, the header returns the value <code>ongoing-request="true"</code>.</p> <p>For more information about archiving objects, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/dev/object-lifecycle-mgmt.html#lifecycle-transition-general-considerations">Transitioning Objects: General Considerations</a>.</p>
+    pub restore: Option<String>,
+    /// <p>If server-side encryption with a customer-provided encryption key was requested, the response will include this header confirming the encryption algorithm used.</p>
+    pub sse_customer_algorithm: Option<String>,
+    /// <p>If server-side encryption with a customer-provided encryption key was requested, the response will include this header to provide round-trip message integrity verification of the customer-provided encryption key.</p>
+    pub sse_customer_key_md5: Option<String>,
+    /// <p>If present, specifies the ID of the AWS Key Management Service (AWS KMS) symmetric customer managed customer master key (CMK) that was used for the object.</p>
+    pub ssekms_key_id: Option<String>,
+    /// <p>If the object is stored using server-side encryption either with an AWS KMS customer master key (CMK) or an Amazon S3-managed encryption key, the response includes this header with the value of the server-side encryption algorithm used when storing this object in Amazon S3 (for example, AES256, aws:kms).</p>
+    pub server_side_encryption: Option<String>,
+    /// <p>Provides storage class information of the object. Amazon S3 returns this header for all objects except for S3 Standard storage class objects.</p> <p>For more information, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/dev/storage-class-intro.html">Storage Classes</a>.</p>
+    pub storage_class: Option<String>,
+    /// <p>Version of the object.</p>
+    pub version_id: Option<String>,
+    /// <p>If the bucket is configured as a website, redirects requests for this object to another object in the same bucket or to an external URL. Amazon S3 stores the value of this header in the object metadata.</p>
+    pub website_redirect_location: Option<String>,
+}
+
 #[derive(Deserialize, Debug)]
 pub struct AwsError {
     #[serde(rename = "Code")]

--- a/s3/src/serde_types.rs
+++ b/s3/src/serde_types.rs
@@ -176,60 +176,94 @@ pub struct CommonPrefix {
 // Taken from https://github.com/rusoto/rusoto
 #[derive(Deserialize, Debug, Default, Clone)]
 pub struct HeadObjectResult {
-    /// <p>Indicates that a range of bytes was specified.</p>
+    #[serde(rename = "AcceptRanges")]
+    /// Indicates that a range of bytes was specified.
     pub accept_ranges: Option<String>,
-    /// <p>Specifies caching behavior along the request/reply chain.</p>
+    #[serde(rename = "CacheControl")]
+    /// Specifies caching behavior along the request/reply chain.
     pub cache_control: Option<String>,
-    /// <p>Specifies presentational information for the object.</p>
+    #[serde(rename = "ContentDisposition")]
+    /// Specifies presentational information for the object.
     pub content_disposition: Option<String>,
-    /// <p>Specifies what content encodings have been applied to the object and thus what decoding mechanisms must be applied to obtain the media-type referenced by the Content-Type header field.</p>
+    #[serde(rename = "ContentEncoding")]
+    /// Specifies what content encodings have been applied to the object and thus what decoding mechanisms must be applied to obtain the media-type referenced by the Content-Type header field.
     pub content_encoding: Option<String>,
-    /// <p>The language the content is in.</p>
+    #[serde(rename = "ContentLanguage")]
+    /// The language the content is in.
     pub content_language: Option<String>,
-    /// <p>Size of the body in bytes.</p>
+    #[serde(rename = "ContentLength")]
+    /// Size of the body in bytes.
     pub content_length: Option<i64>,
-    /// <p>A standard MIME type describing the format of the object data.</p>
+    #[serde(rename = "ContentType")]
+    /// A standard MIME type describing the format of the object data.
     pub content_type: Option<String>,
-    /// <p>Specifies whether the object retrieved was (true) or was not (false) a Delete Marker. If false, this response header does not appear in the response.</p>
+    #[serde(rename = "DeleteMarker")]
+    /// Specifies whether the object retrieved was (true) or was not (false) a Delete Marker.
     pub delete_marker: Option<bool>,
-    /// <p>An ETag is an opaque identifier assigned by a web server to a specific version of a resource found at a URL.</p>
+    #[serde(rename = "ETag")]
+    /// An ETag is an opaque identifier assigned by a web server to a specific version of a resource found at a URL.
     pub e_tag: Option<String>,
-    /// <p>If the object expiration is configured (see PUT Bucket lifecycle), the response includes this header. It includes the expiry-date and rule-id key-value pairs providing object expiration information. The value of the rule-id is URL encoded.</p>
+    #[serde(rename = "Expiration")]
+    /// If the object expiration is configured, the response includes this header. It includes the expiry-date and rule-id key-value pairs providing object expiration information.
+    /// The value of the rule-id is URL encoded.
     pub expiration: Option<String>,
-    /// <p>The date and time at which the object is no longer cacheable.</p>
+    #[serde(rename = "Expires")]
+    /// The date and time at which the object is no longer cacheable.
     pub expires: Option<String>,
-    /// <p>Last modified date of the object</p>
+    #[serde(rename = "LastModified")]
+    /// Last modified date of the object
     pub last_modified: Option<String>,
-    /// <p>A map of metadata to store with the object in S3.</p>
+    #[serde(rename = "Metadata", default)]
+    /// A map of metadata to store with the object in S3.
     pub metadata: Option<::std::collections::HashMap<String, String>>,
-    /// <p>This is set to the number of metadata entries not returned in <code>x-amz-meta</code> headers. This can happen if you create metadata using an API like SOAP that supports more flexible metadata than the REST API. For example, using SOAP, you can create metadata whose values are not legal HTTP headers.</p>
+    #[serde(rename = "MissingMeta")]
+    /// This is set to the number of metadata entries not returned in x-amz-meta headers. This can happen if you create metadata using an API like SOAP that supports more flexible metadata than
+    /// the REST API. For example, using SOAP, you can create metadata whose values are not legal HTTP headers.
     pub missing_meta: Option<i64>,
-    /// <p>Specifies whether a legal hold is in effect for this object. This header is only returned if the requester has the <code>s3:GetObjectLegalHold</code> permission. This header is not returned if the specified version of this object has never had a legal hold applied. For more information about S3 Object Lock, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/dev/object-lock.html">Object Lock</a>.</p>
+    #[serde(rename = "ObjectLockLegalHoldStatus")]
+    /// Specifies whether a legal hold is in effect for this object. This header is only returned if the requester has the s3:GetObjectLegalHold permission.
+    /// This header is not returned if the specified version of this object has never had a legal hold applied.
     pub object_lock_legal_hold_status: Option<String>,
-    /// <p>The Object Lock mode, if any, that's in effect for this object. This header is only returned if the requester has the <code>s3:GetObjectRetention</code> permission. For more information about S3 Object Lock, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/dev/object-lock.html">Object Lock</a>. </p>
+    #[serde(rename = "ObjectLockMode")]
+    /// The Object Lock mode, if any, that's in effect for this object.
     pub object_lock_mode: Option<String>,
-    /// <p>The date and time when the Object Lock retention period expires. This header is only returned if the requester has the <code>s3:GetObjectRetention</code> permission.</p>
+    #[serde(rename = "ObjectLockRetainUntilDate")]
+    /// The date and time when the Object Lock retention period expires.
+    /// This header is only returned if the requester has the s3:GetObjectRetention permission.
     pub object_lock_retain_until_date: Option<String>,
-    /// <p>The count of parts this object has.</p>
+    #[serde(rename = "PartsCount")]
+    /// The count of parts this object has.
     pub parts_count: Option<i64>,
-    /// <p>Amazon S3 can return this header if your request involves a bucket that is either a source or destination in a replication rule.</p> <p>In replication, you have a source bucket on which you configure replication and destination bucket where Amazon S3 stores object replicas. When you request an object (<code>GetObject</code>) or object metadata (<code>HeadObject</code>) from these buckets, Amazon S3 will return the <code>x-amz-replication-status</code> header in the response as follows:</p> <ul> <li> <p>If requesting an object from the source bucket — Amazon S3 will return the <code>x-amz-replication-status</code> header if the object in your request is eligible for replication.</p> <p> For example, suppose that in your replication configuration, you specify object prefix <code>TaxDocs</code> requesting Amazon S3 to replicate objects with key prefix <code>TaxDocs</code>. Any objects you upload with this key name prefix, for example <code>TaxDocs/document1.pdf</code>, are eligible for replication. For any object request with this key name prefix, Amazon S3 will return the <code>x-amz-replication-status</code> header with value PENDING, COMPLETED or FAILED indicating object replication status.</p> </li> <li> <p>If requesting an object from the destination bucket — Amazon S3 will return the <code>x-amz-replication-status</code> header with value REPLICA if the object in your request is a replica that Amazon S3 created.</p> </li> </ul> <p>For more information, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/dev/NotificationHowTo.html">Replication</a>.</p>
+    #[serde(rename = "ReplicationStatus")]
+    /// If your request involves a bucket that is either a source or destination in a replication rule.
     pub replication_status: Option<String>,
+    #[serde(rename = "RequestCharged")]
     pub request_charged: Option<String>,
-    /// <p>If the object is an archived object (an object whose storage class is GLACIER), the response includes this header if either the archive restoration is in progress (see <a>RestoreObject</a> or an archive copy is already restored.</p> <p> If an archive copy is already restored, the header value indicates when Amazon S3 is scheduled to delete the object copy. For example:</p> <p> <code>x-amz-restore: ongoing-request="false", expiry-date="Fri, 23 Dec 2012 00:00:00 GMT"</code> </p> <p>If the object restoration is in progress, the header returns the value <code>ongoing-request="true"</code>.</p> <p>For more information about archiving objects, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/dev/object-lifecycle-mgmt.html#lifecycle-transition-general-considerations">Transitioning Objects: General Considerations</a>.</p>
+    #[serde(rename = "Restore")]
+    /// If the object is an archived object (an object whose storage class is GLACIER), the response includes this header if either the archive restoration is in progress or an archive copy is already restored.
+    /// If an archive copy is already restored, the header value indicates when Amazon S3 is scheduled to delete the object copy.
     pub restore: Option<String>,
-    /// <p>If server-side encryption with a customer-provided encryption key was requested, the response will include this header confirming the encryption algorithm used.</p>
+    #[serde(rename = "SseCustomerAlgorithm")]
+    /// If server-side encryption with a customer-provided encryption key was requested, the response will include this header confirming the encryption algorithm used.
     pub sse_customer_algorithm: Option<String>,
-    /// <p>If server-side encryption with a customer-provided encryption key was requested, the response will include this header to provide round-trip message integrity verification of the customer-provided encryption key.</p>
+    #[serde(rename = "SseCustomerKeyMd5")]
+    /// If server-side encryption with a customer-provided encryption key was requested, the response will include this header to provide round-trip message integrity verification of the customer-provided encryption key.
     pub sse_customer_key_md5: Option<String>,
-    /// <p>If present, specifies the ID of the AWS Key Management Service (AWS KMS) symmetric customer managed customer master key (CMK) that was used for the object.</p>
+    #[serde(rename = "SsekmsKeyId")]
+    /// If present, specifies the ID of the AWS Key Management Service (AWS KMS) symmetric customer managed customer master key (CMK) that was used for the object.
     pub ssekms_key_id: Option<String>,
-    /// <p>If the object is stored using server-side encryption either with an AWS KMS customer master key (CMK) or an Amazon S3-managed encryption key, the response includes this header with the value of the server-side encryption algorithm used when storing this object in Amazon S3 (for example, AES256, aws:kms).</p>
+    #[serde(rename = "ServerSideEncryption")]
+    /// If the object is stored using server-side encryption either with an AWS KMS customer master key (CMK) or an Amazon S3-managed encryption key,
+    /// The response includes this header with the value of the server-side encryption algorithm used when storing this object in Amazon S3 (for example, AES256, aws:kms).
     pub server_side_encryption: Option<String>,
-    /// <p>Provides storage class information of the object. Amazon S3 returns this header for all objects except for S3 Standard storage class objects.</p> <p>For more information, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/dev/storage-class-intro.html">Storage Classes</a>.</p>
+    #[serde(rename = "StorageClass")]
+    /// Provides storage class information of the object. Amazon S3 returns this header for all objects except for S3 Standard storage class objects.
     pub storage_class: Option<String>,
-    /// <p>Version of the object.</p>
+    #[serde(rename = "VersionId")]
+    /// Version of the object.
     pub version_id: Option<String>,
-    /// <p>If the bucket is configured as a website, redirects requests for this object to another object in the same bucket or to an external URL. Amazon S3 stores the value of this header in the object metadata.</p>
+    #[serde(rename = "WebsiteRedirectLocation")]
+    /// If the bucket is configured as a website, redirects requests for this object to another object in the same bucket or to an external URL. Amazon S3 stores the value of this header in the object metadata.
     pub website_redirect_location: Option<String>,
 }
 

--- a/s3/src/utils.rs
+++ b/s3/src/utils.rs
@@ -1,5 +1,7 @@
-use crate::bucket::CHUNK_SIZE;
+use std::str::FromStr;
+
 use crate::Result;
+use crate::{bucket::CHUNK_SIZE, serde_types::HeadObjectResult};
 use async_std::fs::File;
 use async_std::path::Path;
 use futures::io::{AsyncRead, AsyncReadExt};
@@ -65,6 +67,69 @@ pub async fn read_chunk<R: AsyncRead + Unpin>(reader: &mut R) -> Result<Vec<u8>>
         }
     }
     Ok(chunk)
+}
+
+pub trait GetAndConvertHeaders {
+    fn get_and_convert<T: FromStr>(&self, header: &str) -> Option<T>;
+    fn get_string(&self, header: &str) -> Option<String>;
+}
+
+impl GetAndConvertHeaders for http::header::HeaderMap {
+    fn get_and_convert<T: FromStr>(&self, header: &str) -> Option<T> {
+        self.get(header)?.to_str().ok()?.parse::<T>().ok()
+    }
+    fn get_string(&self, header: &str) -> Option<String> {
+        Some(self.get(header)?.to_str().ok()?.to_owned())
+    }
+}
+
+impl From<&http::HeaderMap> for HeadObjectResult {
+    fn from(headers: &http::HeaderMap) -> Self {
+        let mut result = HeadObjectResult::default();
+        result.accept_ranges = headers.get_string("accept-ranges");
+        result.cache_control = headers.get_string("Cache-Control");
+        result.content_disposition = headers.get_string("Content-Disposition");
+        result.content_encoding = headers.get_string("Content-Encoding");
+        result.content_language = headers.get_string("Content-Language");
+        result.content_length = headers.get_and_convert("Content-Length");
+        result.content_type = headers.get_string("Content-Type");
+        result.delete_marker = headers.get_and_convert("x-amz-delete-marker");
+        result.e_tag = headers.get_string("ETag");
+        result.expiration = headers.get_string("x-amz-expiration");
+        result.expires = headers.get_string("Expires");
+        result.last_modified = headers.get_string("Last-Modified");
+        let mut values = ::std::collections::HashMap::new();
+        for (key, value) in headers.iter() {
+            if key.as_str().starts_with("x-amz-meta-") {
+                if let Some(value) = value.to_str().ok() {
+                    values.insert(
+                        key.as_str()["x-amz-meta-".len()..].to_owned(),
+                        value.to_owned(),
+                    );
+                }
+            }
+        }
+        result.metadata = Some(values);
+        result.missing_meta = headers.get_and_convert("x-amz-missing-meta");
+        result.object_lock_legal_hold_status = headers.get_string("x-amz-object-lock-legal-hold");
+        result.object_lock_mode = headers.get_string("x-amz-object-lock-mode");
+        result.object_lock_retain_until_date =
+            headers.get_string("x-amz-object-lock-retain-until-date");
+        result.parts_count = headers.get_and_convert("x-amz-mp-parts-count");
+        result.replication_status = headers.get_string("x-amz-replication-status");
+        result.request_charged = headers.get_string("x-amz-request-charged");
+        result.restore = headers.get_string("x-amz-restore");
+        result.sse_customer_algorithm =
+            headers.get_string("x-amz-server-side-encryption-customer-algorithm");
+        result.sse_customer_key_md5 =
+            headers.get_string("x-amz-server-side-encryption-customer-key-MD5");
+        result.ssekms_key_id = headers.get_string("x-amz-server-side-encryption-aws-kms-key-id");
+        result.server_side_encryption = headers.get_string("x-amz-server-side-encryption");
+        result.storage_class = headers.get_string("x-amz-storage-class");
+        result.version_id = headers.get_string("x-amz-version-id");
+        result.website_redirect_location = headers.get_string("x-amz-website-redirect-location");
+        result
+    }
 }
 
 #[cfg(test)]

--- a/s3/src/utils.rs
+++ b/s3/src/utils.rs
@@ -101,7 +101,7 @@ impl From<&http::HeaderMap> for HeadObjectResult {
         let mut values = ::std::collections::HashMap::new();
         for (key, value) in headers.iter() {
             if key.as_str().starts_with("x-amz-meta-") {
-                if let Some(value) = value.to_str().ok() {
+                if let Ok(value) = value.to_str() {
                     values.insert(
                         key.as_str()["x-amz-meta-".len()..].to_owned(),
                         value.to_owned(),


### PR DESCRIPTION
Added the HeadObject command.

I have updated the tests to include this command.
I only have access to AWS so I was only able to actually run the aws tests:
* `test_put_head_get_delete_object` 
* `test_put_head_get_delete_object_blocking`

I'm assuming that they will pass for GC and wasabi.

Please let me know if I can make any improvements or if there is a better way to make the changes etc.