### PR TITLE
Delete a dependency on async-std when tokio is selected

### DIFF
--- a/s3/Cargo.toml
+++ b/s3/Cargo.toml
@@ -49,7 +49,7 @@ url = "2"
 block_on_proc = { version = "0.1", optional = true }
 
 [features]
-with-tokio = ["reqwest", "tokio", "futures", "async-std"]
+with-tokio = ["reqwest", "tokio", "futures", "tokio/fs"]
 with-async-std = ["async-std", "surf", "futures"]
 sync = ["attohttpc", "maybe-async/is_sync"]
 default = ["tokio-native-tls"]

--- a/s3/src/bucket.rs
+++ b/s3/src/bucket.rs
@@ -16,12 +16,15 @@ pub type Query = HashMap<String, String>;
 use crate::request::Reqwest as RequestImpl;
 #[cfg(feature = "with-async-std")]
 use crate::surf_request::SurfRequest as RequestImpl;
-#[cfg(any(feature = "with-tokio", feature = "with-async-std"))]
-use async_std::fs::File;
-#[cfg(any(feature = "with-tokio", feature = "with-async-std"))]
-use async_std::path::Path;
-#[cfg(any(feature = "with-tokio", feature = "with-async-std"))]
+#[cfg(feature = "with-async-std")]
+use async_std::{fs::File, path::Path};
+#[cfg(feature = "with-tokio")]
+use tokio::fs::File;
+
+#[cfg(feature = "with-async-std")]
 use futures::io::AsyncRead;
+#[cfg(feature = "with-tokio")]
+use tokio::io::AsyncRead;
 
 #[cfg(feature = "sync")]
 use crate::blocking::AttoRequest as RequestImpl;
@@ -29,7 +32,7 @@ use crate::blocking::AttoRequest as RequestImpl;
 use std::fs::File;
 #[cfg(feature = "sync")]
 use std::io::Read;
-#[cfg(feature = "sync")]
+#[cfg(any(feature = "sync", feature = "with-tokio"))]
 use std::path::Path;
 
 use crate::request_trait::Request;


### PR DESCRIPTION
Hello, this tiny PR removes the dependency on async-std when he feature flag `with-tokio` is enabled (in the current state, this means that we are pulling the async-std runtime and dependency tree even when we only make use of the tokio runtime).

Happy holidays, and many thanks for this crate, by the way :)