### PR TITLE
add custom headers on put_object requests

### DIFF
--- a/s3/src/bucket.rs
+++ b/s3/src/bucket.rs
@@ -565,7 +565,7 @@ impl Bucket {
     /// // Blocking variant, generated with `blocking` feature in combination
     /// // with `tokio` or `async-std` features.
     /// #[cfg(feature = "blocking")]
-    /// let status_code = bucket.put_object_stream_blocking(&mut path, "/path")?;
+    /// let status_code = bucket.put_object_stream_blocking(&mut file, "/path")?;
     /// #
     /// # Ok(())
     /// # }
@@ -576,7 +576,8 @@ impl Bucket {
         reader: &mut R,
         s3_path: impl AsRef<str>,
     ) -> Result<u16> {
-        self._put_object_stream(reader, s3_path.as_ref()).await
+        self.put_object_stream_with_headers(reader, s3_path, None)
+            .await
     }
 
     #[maybe_async::sync_impl]
@@ -585,17 +586,69 @@ impl Bucket {
         reader: &mut R,
         s3_path: impl AsRef<str>,
     ) -> Result<u16> {
-        self._put_object_stream(reader, s3_path.as_ref())
+        self.put_object_stream_with_headers(reader, s3_path.as_ref(), None)
     }
 
+    /// Stream file from local path to s3, generic over T: Write, with custom headers.
+    ///
+    /// # Example:
+    ///
+    /// ```rust,no_run
+    /// use s3::bucket::Bucket;
+    /// use s3::creds::Credentials;
+    /// use std::fs::File;
+    /// use std::io::Write;
+    /// use http::header::{HeaderMap, HeaderName, HeaderValue};
+    /// use anyhow::Result;
+    ///
+    /// # #[tokio::main]
+    /// # async fn main() -> Result<()> {
+    ///
+    /// let bucket_name = "rust-s3-test";
+    /// let region = "us-east-1".parse()?;
+    /// let credentials = Credentials::default()?;
+    /// let bucket = Bucket::new(bucket_name, region, credentials)?;
+    /// let path = "path";
+    /// let test: Vec<u8> = (0..1000).map(|_| 42).collect();
+    /// let mut file = File::create(path)?;
+    /// file.write_all(&test)?;
+    ///
+    /// let mut headers = HeaderMap::new();
+    /// headers.insert(HeaderName::from_static("x-amz-meta-origin"), HeaderValue::from_static("Europe/France"));
+    ///
+    /// #[cfg(feature = "with-tokio")]
+    /// let mut path = tokio::fs::File::open(path).await?;
+    ///
+    /// #[cfg(feature = "with-async-std")]
+    /// let mut path = async_std::fs::File::open(path).await?;
+    /// // Async variant with `tokio` or `async-std` features
+    /// // Generic over futures::io::AsyncRead|tokio::io::AsyncRead + Unpin
+    /// let status_code = bucket.put_object_stream_with_headers(&mut path, "/path", Some(headers)).await?;
+    ///
+    /// // `sync` feature will produce an identical method
+    /// #[cfg(feature = "sync")]
+    /// // Generic over std::io::Read
+    /// let status_code = bucket.put_object_stream_with_headers(&mut path, "/path", Some(headers))?;
+    ///
+    /// // Blocking variant, generated with `blocking` feature in combination
+    /// // with `tokio` or `async-std` features.
+    /// #[cfg(feature = "blocking")]
+    /// let status_code = bucket.put_object_stream_with_headers_blocking(&mut file, "/path", Some(headers))?;
+    /// #
+    /// # Ok(())
+    /// # }
+    /// ```
     #[maybe_async::async_impl]
-    async fn _put_object_stream<R: AsyncRead + Unpin>(
+    pub async fn put_object_stream_with_headers<R: AsyncRead + Unpin>(
         &self,
         reader: &mut R,
-        s3_path: &str,
+        s3_path: impl AsRef<str>,
+        custom_headers: Option<HeaderMap>,
     ) -> Result<u16> {
-        let command = Command::InitiateMultipartUpload;
-        let request = RequestImpl::new(self, &s3_path, command);
+        let command = Command::InitiateMultipartUpload {
+            custom_headers: custom_headers.clone(),
+        };
+        let request = RequestImpl::new(self, s3_path.as_ref(), command);
         let (data, code) = request.response_data(false).await?;
         let msg: InitiateMultipartUploadResponse =
             serde_xml::from_str(std::str::from_utf8(data.as_slice())?)?;
@@ -621,6 +674,7 @@ impl Bucket {
                         content: &chunk,
                         content_type: "application/octet-stream",
                         multipart: Some(Multipart::new(part_number, upload_id)), // upload_id: &msg.upload_id,
+                        custom_headers: custom_headers.clone(),
                     };
                     let request = RequestImpl::new(self, &path, command);
                     let (data, _code) = request.response_data(true).await?;
@@ -652,6 +706,7 @@ impl Bucket {
                     content: &chunk,
                     content_type: "application/octet-stream",
                     multipart: Some(Multipart::new(part_number, upload_id)), // upload_id: &msg.upload_id,
+                    custom_headers: custom_headers.clone(),
                 };
                 let request = RequestImpl::new(self, &path, command);
                 let (data, _code) = request.response_data(true).await?;
@@ -663,9 +718,16 @@ impl Bucket {
     }
 
     #[maybe_async::sync_impl]
-    fn _put_object_stream<R: Read>(&self, reader: &mut R, s3_path: &str) -> Result<u16> {
-        let command = Command::InitiateMultipartUpload;
-        let request = RequestImpl::new(self, &s3_path, command);
+    pub fn put_object_stream_with_headers<R: Read>(
+        &self,
+        reader: &mut R,
+        s3_path: impl AsRef<str>,
+        custom_headers: Option<HeaderMap>,
+    ) -> Result<u16> {
+        let command = Command::InitiateMultipartUpload {
+            custom_headers: custom_headers.clone(),
+        };
+        let request = RequestImpl::new(self, s3_path.as_ref(), command);
         let (data, code) = request.response_data(false)?;
         let msg: InitiateMultipartUploadResponse =
             serde_xml::from_str(std::str::from_utf8(data.as_slice())?)?;
@@ -692,6 +754,7 @@ impl Bucket {
                         content: &chunk,
                         content_type: "application/octet-stream",
                         multipart: Some(Multipart::new(part_number, upload_id)), // upload_id: &msg.upload_id,
+                        custom_headers,
                     };
                     let request = RequestImpl::new(self, &path, command);
                     let (data, _code) = request.response_data(true)?;
@@ -721,6 +784,7 @@ impl Bucket {
                     content: &chunk,
                     content_type: "application/octet-stream",
                     multipart: Some(Multipart::new(part_number, upload_id)),
+                    custom_headers: custom_headers.clone(),
                 };
                 let request = RequestImpl::new(self, &path, command);
                 let (data, _code) = request.response_data(true)?;
@@ -870,6 +934,61 @@ impl Bucket {
         Ok((header_object, status))
     }
 
+    /// Put into an S3 bucket, with explicit content-type and headers.
+    ///
+    /// # Example:
+    ///
+    /// ```no_run
+    /// use s3::bucket::Bucket;
+    /// use s3::creds::Credentials;
+    /// use anyhow::Result;
+    /// use http::header::{HeaderMap, HeaderName, HeaderValue};
+    ///
+    /// # #[tokio::main]
+    /// # async fn main() -> Result<()> {
+    ///
+    /// let bucket_name = "rust-s3-test";
+    /// let region = "us-east-1".parse()?;
+    /// let credentials = Credentials::default()?;
+    /// let bucket = Bucket::new(bucket_name, region, credentials)?;
+    /// let content = "I want to go to S3".as_bytes();
+    ///
+    /// let mut headers = HeaderMap::new();
+    /// headers.insert(HeaderName::from_static("x-amz-meta-origin"), HeaderValue::from_static("Europe/France"));
+    ///
+    /// // Async variant with `tokio` or `async-std` features
+    /// let (_, code) = bucket.put_object_with_content_type_and_headers("/test.file", content, "text/plain", Some(headers)).await?;
+    ///
+    /// // `sync` feature will produce an identical method
+    /// #[cfg(feature = "sync")]
+    /// let (_, code) = bucket.put_object_with_content_type_and_headers("/test.file", content, "text/plain", Some(headers))?;
+    ///
+    /// // Blocking variant, generated with `blocking` feature in combination
+    /// // with `tokio` or `async-std` features.
+    /// #[cfg(feature = "blocking")]
+    /// let (_, code) = bucket.put_object_with_content_type_and_headers_blocking("/test.file", content, "text/plain", Some(headers))?;
+    /// #
+    /// # Ok(())
+    /// # }
+    /// ```
+    #[maybe_async::maybe_async]
+    pub async fn put_object_with_content_type_and_headers<S: AsRef<str>>(
+        &self,
+        path: S,
+        content: &[u8],
+        content_type: &str,
+        custom_headers: Option<HeaderMap>,
+    ) -> Result<(Vec<u8>, u16)> {
+        let command = Command::PutObject {
+            content,
+            content_type,
+            multipart: None,
+            custom_headers,
+        };
+        let request = RequestImpl::new(self, path.as_ref(), command);
+        Ok(request.response_data(true).await?)
+    }
+
     /// Put into an S3 bucket, with explicit content-type.
     ///
     /// # Example:
@@ -910,13 +1029,8 @@ impl Bucket {
         content: &[u8],
         content_type: &str,
     ) -> Result<(Vec<u8>, u16)> {
-        let command = Command::PutObject {
-            content,
-            content_type,
-            multipart: None,
-        };
-        let request = RequestImpl::new(self, path.as_ref(), command);
-        Ok(request.response_data(true).await?)
+        self.put_object_with_content_type_and_headers(path, content, content_type, None)
+            .await
     }
 
     /// Put into an S3 bucket.
@@ -958,8 +1072,13 @@ impl Bucket {
         path: S,
         content: &[u8],
     ) -> Result<(Vec<u8>, u16)> {
-        self.put_object_with_content_type(path, content, "application/octet-stream")
-            .await
+        self.put_object_with_content_type_and_headers(
+            path,
+            content,
+            "application/octet-stream",
+            None,
+        )
+        .await
     }
 
     fn _tags_xml<S: AsRef<str>>(&self, tags: &[(S, S)]) -> String {

--- a/s3/src/command.rs
+++ b/s3/src/command.rs
@@ -64,6 +64,7 @@ pub enum Command<'a> {
         content: &'a [u8],
         content_type: &'a str,
         multipart: Option<Multipart<'a>>,
+        custom_headers: Option<HeaderMap>,
     },
     PutObjectTagging {
         tags: &'a str,
@@ -89,7 +90,9 @@ pub enum Command<'a> {
         expiry_secs: u32,
         custom_headers: Option<HeaderMap>,
     },
-    InitiateMultipartUpload,
+    InitiateMultipartUpload {
+        custom_headers: Option<HeaderMap>,
+    },
     UploadPart {
         part_number: u32,
         content: &'a [u8],
@@ -127,7 +130,7 @@ impl<'a> Command<'a> {
             | Command::DeleteObjectTagging
             | Command::AbortMultipartUpload { .. }
             | Command::DeleteBucket => HttpMethod::Delete,
-            Command::InitiateMultipartUpload | Command::CompleteMultipartUpload { .. } => {
+            Command::InitiateMultipartUpload { .. } | Command::CompleteMultipartUpload { .. } => {
                 HttpMethod::Post
             }
             Command::HeadObject => HttpMethod::Head,

--- a/s3/src/request_trait.rs
+++ b/s3/src/request_trait.rs
@@ -190,7 +190,7 @@ pub trait Request {
 
         // Append to url_path
         match self.command() {
-            Command::InitiateMultipartUpload | Command::ListMultipartUploads { .. } => {
+            Command::InitiateMultipartUpload { .. } | Command::ListMultipartUploads { .. } => {
                 url_str.push_str("?uploads")
             }
             Command::AbortMultipartUpload { upload_id } => {
@@ -389,6 +389,16 @@ pub trait Request {
             headers.insert(RANGE, range.parse().unwrap());
         } else if let Command::CreateBucket { ref config } = self.command() {
             config.add_headers(&mut headers)?;
+        }
+
+        if let Command::PutObject { custom_headers, .. }
+        | Command::InitiateMultipartUpload { custom_headers } = self.command()
+        {
+            if let Some(custom_headers) = custom_headers {
+                for (name, value) in custom_headers.iter() {
+                    headers.insert(name.clone(), value.clone());
+                }
+            }
         }
 
         // This must be last, as it signs the other headers, omitted if no secret key is provided


### PR DESCRIPTION
Hello again.

I'm quite lazy, so I didn't want to upload objects with a presigned put (which allows for passing custom metadata). This means I had to be able to pass custom headers (in theory I only needed to add "x-amz-meta-*", but while we are at it, wa can as well let the user add any possible header, right ?). This is an attempt at solving this problem.
However, I do think that this PR is less than ideal because
1) a builder pattern would probably prevent adding too many similar functions, and be better than this hacky patch
2) we forward `custom_headers` to the s3 endpoint both for submitting parts & for initiating the upload, without distinguishing both (in the event of a multi-parts upload of course, otherwise there is no such dichotomy because there is only a single request). However adding two arguments would be tedious and there is no way to distinguish the headers targeting the parts from those targeting the `InitiateMultipartUpload` query. So I decided to send the same headers for both.

Anyway, do you think something like that would be valuable ?
