### PR TITLE
Use thiserror to manage errors in rust-s3

### DIFF
--- a/aws-creds/Cargo.toml
+++ b/aws-creds/Cargo.toml
@@ -15,7 +15,7 @@ name = "awscreds"
 path = "src/lib.rs"
 
 [dependencies]
-anyhow = "1.0"
+thiserror = "1.0"
 dirs = "3"
 rust-ini = "0.16"
 attohttpc = { version = "0.16", default-features = false, features = ["json"] }

--- a/aws-creds/src/credentials.rs
+++ b/aws-creds/src/credentials.rs
@@ -1,7 +1,5 @@
 #![allow(dead_code)]
 
-use anyhow::anyhow;
-use anyhow::Result;
 use ini::Ini;
 use serde_xml_rs as serde_xml;
 use std::collections::HashMap;
@@ -114,8 +112,43 @@ pub struct ResponseMetadata {
     pub request_id: String,
 }
 
+#[derive(thiserror::Error, Debug)]
+pub enum Error {
+    #[error("Environment variable not found: {0}")]
+    AbsentVar(#[from] env::VarError),
+    #[error("Invalid url: {0}")]
+    InvalidUrl(#[from] url::ParseError),
+    #[error("Not an EC2 instance")]
+    NotEC2,
+    #[error("HTTP issue: {0}")]
+    AttohttpcError(#[from] attohttpc::Error),
+    #[error("File manipulation failed: {0}")]
+    IoError(#[from] std::io::Error),
+    #[error("Custom error: {0}")]
+    Custom(String),
+    #[error("XML deserialization error: {0}")]
+    XmlDeserializationError(#[from] serde_xml_rs::Error),
+    #[error("Invalid ini file: {0}")]
+    IniParsingError(ini::ParseError),
+}
+
+impl From<String> for Error {
+    fn from(v: String) -> Error {
+        Error::Custom(v)
+    }
+}
+
+impl From<ini::Error> for Error {
+    fn from(v: ini::Error) -> Error {
+        match v {
+            ini::Error::Io(e) => Error::IoError(e),
+            ini::Error::Parse(e) => Error::IniParsingError(e),
+        }
+    }
+}
+
 impl Credentials {
-    pub fn from_sts_env(session_name: &str) -> Result<Credentials> {
+    pub fn from_sts_env(session_name: &str) -> Result<Credentials, Error> {
         let role_arn = env::var("AWS_ROLE_ARN")?;
         let web_identity_token_file = env::var("AWS_WEB_IDENTITY_TOKEN_FILE")?;
         let web_identity_token = std::fs::read_to_string(web_identity_token_file)?;
@@ -126,7 +159,7 @@ impl Credentials {
         role_arn: &str,
         session_name: &str,
         web_identity_token: &str,
-    ) -> Result<Credentials> {
+    ) -> Result<Credentials, Error> {
         let url = Url::parse_with_params(
             "https://sts.amazonaws.com/",
             &[
@@ -165,17 +198,17 @@ impl Credentials {
         })
     }
 
-    pub fn default() -> Result<Credentials> {
+    pub fn default() -> Result<Credentials, Error> {
         Credentials::new(None, None, None, None, None)
     }
 
-    pub fn anonymous() -> Result<Credentials> {
-        Ok(Credentials {
+    pub fn anonymous() -> Credentials {
+        Credentials {
             access_key: None,
             secret_key: None,
             security_token: None,
             session_token: None,
-        })
+        }
     }
 
     /// Initialize Credentials directly with key ID, secret key, and optional
@@ -186,7 +219,7 @@ impl Credentials {
         security_token: Option<&str>,
         session_token: Option<&str>,
         profile: Option<&str>,
-    ) -> Result<Credentials> {
+    ) -> Result<Credentials, Error> {
         if access_key.is_some() {
             return Ok(Credentials {
                 access_key: access_key.map(|s| s.to_string()),
@@ -207,7 +240,7 @@ impl Credentials {
         secret_key_var: Option<&str>,
         security_token_var: Option<&str>,
         session_token_var: Option<&str>,
-    ) -> Result<Credentials> {
+    ) -> Result<Credentials, Error> {
         let access_key = from_env_with_default(access_key_var, "AWS_ACCESS_KEY_ID")?;
         let secret_key = from_env_with_default(secret_key_var, "AWS_SECRET_ACCESS_KEY")?;
 
@@ -221,13 +254,13 @@ impl Credentials {
         })
     }
 
-    pub fn from_env() -> Result<Credentials> {
+    pub fn from_env() -> Result<Credentials, Error> {
         Credentials::from_env_specific(None, None, None, None)
     }
 
-    pub fn from_instance_metadata() -> Result<Credentials> {
+    pub fn from_instance_metadata() -> Result<Credentials, Error> {
         if !Credentials::is_ec2() {
-            return Err(anyhow!("Not an EC2 instance"));
+            return Err(Error::NotEC2);
         }
         let mut resp: HashMap<String, String> =
             match env::var("AWS_CONTAINER_CREDENTIALS_RELATIVE_URI") {
@@ -277,22 +310,22 @@ impl Credentials {
         false
     }
 
-    pub fn from_profile(section: Option<&str>) -> Result<Credentials> {
-        let home_dir = dirs::home_dir().ok_or_else(|| anyhow!("Invalid home dir"))?;
+    pub fn from_profile(section: Option<&str>) -> Result<Credentials, Error> {
+        let home_dir = dirs::home_dir().ok_or_else(|| String::from("Invalid home dir"))?;
         let profile = format!("{}/.aws/credentials", home_dir.display());
         let conf = Ini::load_from_file(&profile)?;
         let section = section.unwrap_or("default");
         let data = conf
             .section(Some(section))
-            .ok_or_else(|| anyhow!("Config missing"))?;
+            .ok_or_else(|| String::from("Config missing"))?;
         let access_key = data
             .get("aws_access_key_id")
             .map(|s| s.to_string())
-            .ok_or_else(|| anyhow!("Missing aws_access_key_id section"))?;
+            .ok_or_else(|| String::from("Missing aws_access_key_id section"))?;
         let secret_key = data
             .get("aws_secret_access_key")
             .map(|s| s.to_string())
-            .ok_or_else(|| anyhow!("Missing aws_secret_access_key section"))?;
+            .ok_or_else(|| String::from("Missing aws_secret_access_key section"))?;
         let credentials = Credentials {
             access_key: Some(access_key),
             secret_key: Some(secret_key),
@@ -303,13 +336,13 @@ impl Credentials {
     }
 }
 
-fn from_env_with_default(var: Option<&str>, default: &str) -> Result<String> {
+fn from_env_with_default(var: Option<&str>, default: &str) -> Result<String, Error> {
     let val = var.unwrap_or(default);
-    env::var(val).or_else(|_e| env::var(val)).map_err(|_| {
-        anyhow!(
+    env::var(val).or_else(|_| env::var(val)).map_err(|_| {
+        format!(
             "Neither {:?}, nor {} does not exist in the environment",
-            var,
-            default
+            var, default
         )
+        .into()
     })
 }

--- a/aws-region/Cargo.toml
+++ b/aws-region/Cargo.toml
@@ -13,6 +13,3 @@ edition = "2018"
 [lib]
 name = "awsregion"
 path = "src/lib.rs"
-
-[dependencies]
-anyhow = "1.0"

--- a/aws-region/src/region.rs
+++ b/aws-region/src/region.rs
@@ -3,8 +3,6 @@
 use std::fmt;
 use std::str::{self, FromStr};
 
-use anyhow::Result;
-
 /// AWS S3 [region identifier](https://docs.aws.amazon.com/general/latest/gr/rande.html#s3_region),
 /// passing in custom values is also possible, in that case it is up to you to pass a valid endpoint,
 /// otherwise boom will happen :)
@@ -15,7 +13,7 @@ use anyhow::Result;
 /// use awsregion::Region;
 ///
 /// // Parse from a string
-/// let region: Region = "us-east-1".parse().unwrap();
+/// let region: Region = Region::from("us-east-1");
 ///
 /// // Choose region directly
 /// let region = Region::EuWest2;
@@ -128,46 +126,44 @@ impl fmt::Display for Region {
     }
 }
 
-impl FromStr for Region {
-    type Err = anyhow::Error;
-
-    fn from_str(s: &str) -> Result<Self> {
+impl From<&str> for Region {
+    fn from(s: &str) -> Region {
         use self::Region::*;
         match s {
-            "us-east-1" => Ok(UsEast1),
-            "us-east-2" => Ok(UsEast2),
-            "us-west-1" => Ok(UsWest1),
-            "us-west-2" => Ok(UsWest2),
-            "ca-central-1" => Ok(CaCentral1),
-            "ap-south-1" => Ok(ApSouth1),
-            "ap-northeast-1" => Ok(ApNortheast1),
-            "ap-northeast-2" => Ok(ApNortheast2),
-            "ap-northeast-3" => Ok(ApNortheast3),
-            "ap-southeast-1" => Ok(ApSoutheast1),
-            "ap-southeast-2" => Ok(ApSoutheast2),
-            "cn-north-1" => Ok(CnNorth1),
-            "cn-northwest-1" => Ok(CnNorthwest1),
-            "eu-north-1" => Ok(EuNorth1),
-            "eu-central-1" => Ok(EuCentral1),
-            "eu-west-1" => Ok(EuWest1),
-            "eu-west-2" => Ok(EuWest2),
-            "eu-west-3" => Ok(EuWest3),
-            "sa-east-1" => Ok(SaEast1),
-            "me-south-1" => Ok(MeSouth1),
-            "nyc3" => Ok(DoNyc3),
-            "ams3" => Ok(DoAms3),
-            "sgp1" => Ok(DoSgp1),
-            "fra1" => Ok(DoFra1),
-            "yandex" => Ok(Yandex),
-            "ru-central1" => Ok(Yandex),
-            "wa-us-east-1" => Ok(WaUsEast1),
-            "wa-us-east-2" => Ok(WaUsEast2),
-            "wa-us-west-1" => Ok(WaUsWest1),
-            "wa-eu-central-1" => Ok(WaEuCentral1),
-            x => Ok(Custom {
+            "us-east-1" => UsEast1,
+            "us-east-2" => UsEast2,
+            "us-west-1" => UsWest1,
+            "us-west-2" => UsWest2,
+            "ca-central-1" => CaCentral1,
+            "ap-south-1" => ApSouth1,
+            "ap-northeast-1" => ApNortheast1,
+            "ap-northeast-2" => ApNortheast2,
+            "ap-northeast-3" => ApNortheast3,
+            "ap-southeast-1" => ApSoutheast1,
+            "ap-southeast-2" => ApSoutheast2,
+            "cn-north-1" => CnNorth1,
+            "cn-northwest-1" => CnNorthwest1,
+            "eu-north-1" => EuNorth1,
+            "eu-central-1" => EuCentral1,
+            "eu-west-1" => EuWest1,
+            "eu-west-2" => EuWest2,
+            "eu-west-3" => EuWest3,
+            "sa-east-1" => SaEast1,
+            "me-south-1" => MeSouth1,
+            "nyc3" => DoNyc3,
+            "ams3" => DoAms3,
+            "sgp1" => DoSgp1,
+            "fra1" => DoFra1,
+            "yandex" => Yandex,
+            "ru-central1" => Yandex,
+            "wa-us-east-1" => WaUsEast1,
+            "wa-us-east-2" => WaUsEast2,
+            "wa-us-west-1" => WaUsWest1,
+            "wa-eu-central-1" => WaEuCentral1,
+            x => Custom {
                 region: x.to_string(),
                 endpoint: x.to_string(),
-            }),
+            },
         }
     }
 }
@@ -239,7 +235,7 @@ fn yandex_object_storage() {
         region: "ru-central1".to_string(),
     };
 
-    let yandex_region = "ru-central1".parse::<Region>().unwrap();
+    let yandex_region = Region::from("ru-central1");
 
     assert_eq!(yandex.endpoint(), yandex_region.endpoint());
 

--- a/s3/Cargo.toml
+++ b/s3/Cargo.toml
@@ -22,14 +22,16 @@ path = "src/lib.rs"
 async-std = { version = "1", optional = true }
 async-trait = "0.1"
 attohttpc = { version = "0.16", optional = true, default-features = false }
-aws-creds = { version = "0.26", default-features = false }
-aws-region = "0.23"
+aws-creds = { path = "../aws-creds", default-features = false }
+aws-region = { path = "../aws-region" }
 base64 = "0.13.0"
 cfg-if = "1"
 chrono = "0.4"
 futures = { version = "0.3", optional = true }
 hex = "0.4"
 hmac = "0.10"
+# necessary to access InvalidKeylength to derive precise errors (and imported by the hmac crate above anyway)
+crypto-mac = "0.10"
 http = "0.2"
 log = "0.4"
 maybe-async = { version = "0.2" }
@@ -40,7 +42,7 @@ serde = "1"
 serde_derive = "1"
 serde-xml-rs = "0.4"
 sha2 = "0.9"
-anyhow = "1.0"
+thiserror = "1.0"
 surf = { version = "2", optional = true, default-features = false, features = ["hyper-client"] }
 tokio = { version = "1", features = ["io-util"], optional = true, default-features = false }
 tokio-stream = "0.1"
@@ -67,3 +69,4 @@ tokio = { version = "1", features = ["rt", "rt-multi-thread", "macros"] }
 async-std = { version = "1", features = ["attributes"] }
 uuid = { version = "0.8", features = ["v4"] }
 env_logger = "0.8"
+anyhow = "1.0"

--- a/s3/Makefile
+++ b/s3/Makefile
@@ -9,7 +9,7 @@ sync-clippy: sync-nativetls-clippy sync-nossl-clippy sync-rustlstls-clippy
 
 # tokio
 tokio: tokio-nativetls tokio-nossl tokio-noverify tokio-rustlstls
-tokio-not-ignored: tokio-nativetls-test-not-ignored tokio-nossl-test-not-ignored tokio-noverify-test-not-ignored tokio-rustlstls-test-not-ignored
+tokio-not-ignored: tokio-nativetls-test-not-ignored tokio-nossl-test-not-ignored tokio-noverify-test-not-ignored tokio-rustlstls-test-not-ignored sync-nativetls-test-not-ignored sync-rustlstls-test-not-ignored
 
 tokio-nativetls: tokio-nativetls-clippy tokio-nativetls-test tokio-nativetls-blocking-test-ignored
 tokio-nativetls-clippy:
@@ -57,17 +57,21 @@ async-std-test-blocking-ignored:
 # sync
 sync-nativetls: sync-nativetls-clippy sync-nativetls-test
 sync-nativetls-clippy:
-	cargo clippy --no-default-features --features sync --features sync-native-tls -- -D warnings
-sync-nativetls-test: sync-nativetls-test-ignored
+	cargo clippy --no-default-features --features sync-native-tls -- -D warnings
+sync-nativetls-test: sync-nativetls-test-ignored sync-nativetls-test-not-ignored
 sync-nativetls-test-ignored:
-	cargo test --no-default-features --features sync --features sync-native-tls -- --ignored
+	cargo test --no-default-features --features sync-native-tls -- --ignored
+sync-nativetls-test-not-ignored:
+	cargo test --no-default-features --features sync-native-tls
 
 sync-rustlstls: sync-rustlstls-clippy sync-rustlstls-test
 sync-rustlstls-clippy:
-	cargo clippy --no-default-features --features sync --features sync-rustls-tls -- -D warnings
-sync-rustlstls-test: sync-rustlstls-test-ignored
+	cargo clippy --no-default-features --features sync-rustls-tls -- -D warnings
+sync-rustlstls-test: sync-rustlstls-test-ignored sync-rustlstls-test-not-ignored
 sync-rustlstls-test-ignored:
-	cargo test --no-default-features --features sync --features sync-rustls-tls -- --ignored
+	cargo test --no-default-features --features sync-rustls-tls -- --ignored
+sync-rustlstls-test-not-ignored:
+	cargo test --no-default-features --features sync-rustls-tls
 
 sync-nossl: sync-nossl-clippy
 sync-nossl-clippy:

--- a/s3/src/blocking.rs
+++ b/s3/src/blocking.rs
@@ -10,9 +10,8 @@ use super::command::Command;
 use chrono::{DateTime, Utc};
 
 use crate::command::HttpMethod;
+use crate::errors::ResponseError;
 use crate::request_trait::Request;
-use anyhow::anyhow;
-use anyhow::Result;
 // static CLIENT: Lazy<Client> = Lazy::new(|| {
 //     if cfg!(feature = "no-verify-ssl") {
 //         Client::builder()
@@ -54,12 +53,9 @@ impl<'a> Request for AttoRequest<'a> {
         self.path.to_string()
     }
 
-    fn response(&self) -> Result<Self::Response> {
+    fn response(&self) -> Result<Self::Response, ResponseError> {
         // Build headers
-        let headers = match self.headers() {
-            Ok(headers) => headers,
-            Err(e) => return Err(e),
-        };
+        let headers = self.headers()?;
 
         let mut session = attohttpc::Session::new();
 
@@ -78,17 +74,16 @@ impl<'a> Request for AttoRequest<'a> {
         let response = request.bytes(&self.request_body()).send()?;
 
         if cfg!(feature = "fail-on-err") && response.status().as_u16() >= 400 {
-            return Err(anyhow!(
-                "Request failed with code {}\n{}",
+            return Err(ResponseError::StatusCode(
                 response.status().as_u16(),
-                response.text()?
+                Some(response.text()?),
             ));
         }
 
         Ok(response)
     }
 
-    fn response_data(&self, etag: bool) -> Result<(Vec<u8>, u16)> {
+    fn response_data(&self, etag: bool) -> Result<(Vec<u8>, u16), ResponseError> {
         let response = self.response()?;
         let status_code = response.status().as_u16();
         let headers = response.headers().clone();
@@ -104,7 +99,7 @@ impl<'a> Request for AttoRequest<'a> {
         Ok((body_vec, status_code))
     }
 
-    fn response_data_to_writer<T: Write>(&self, writer: &mut T) -> Result<u16> {
+    fn response_data_to_writer<T: Write>(&self, writer: &mut T) -> Result<u16, ResponseError> {
         let response = self.response()?;
 
         let status_code = response.status();
@@ -115,7 +110,7 @@ impl<'a> Request for AttoRequest<'a> {
         Ok(status_code.as_u16())
     }
 
-    fn response_header(&self) -> Result<(Self::HeaderMap, u16)> {
+    fn response_header(&self) -> Result<(Self::HeaderMap, u16), ResponseError> {
         let response = self.response()?;
         let status_code = response.status().as_u16();
         let headers = response.headers().clone();
@@ -141,6 +136,7 @@ mod tests {
     use crate::bucket::Bucket;
     use crate::command::Command;
     use crate::request_trait::Request;
+    use crate::Region;
     use anyhow::Result;
     use awscreds::Credentials;
 
@@ -154,8 +150,8 @@ mod tests {
 
     #[test]
     fn url_uses_https_by_default() -> Result<()> {
-        let region = "custom-region".parse()?;
-        let bucket = Bucket::new("my-first-bucket", region, fake_credentials())?;
+        let region = Region::from("custom-region");
+        let bucket = Bucket::new("my-first-bucket", region, fake_credentials());
         let path = "/my-first/path";
         let request = AttoRequest::new(&bucket, path, Command::GetObject);
 
@@ -170,8 +166,8 @@ mod tests {
 
     #[test]
     fn url_uses_https_by_default_path_style() -> Result<()> {
-        let region = "custom-region".parse()?;
-        let bucket = Bucket::new_with_path_style("my-first-bucket", region, fake_credentials())?;
+        let region = Region::from("custom-region");
+        let bucket = Bucket::new_with_path_style("my-first-bucket", region, fake_credentials());
         let path = "/my-first/path";
         let request = AttoRequest::new(&bucket, path, Command::GetObject);
 
@@ -186,8 +182,8 @@ mod tests {
 
     #[test]
     fn url_uses_scheme_from_custom_region_if_defined() -> Result<()> {
-        let region = "http://custom-region".parse()?;
-        let bucket = Bucket::new("my-second-bucket", region, fake_credentials())?;
+        let region = Region::from("http://custom-region");
+        let bucket = Bucket::new("my-second-bucket", region, fake_credentials());
         let path = "/my-second/path";
         let request = AttoRequest::new(&bucket, path, Command::GetObject);
 
@@ -201,8 +197,8 @@ mod tests {
 
     #[test]
     fn url_uses_scheme_from_custom_region_if_defined_with_path_style() -> Result<()> {
-        let region = "http://custom-region".parse()?;
-        let bucket = Bucket::new_with_path_style("my-second-bucket", region, fake_credentials())?;
+        let region = Region::from("http://custom-region");
+        let bucket = Bucket::new_with_path_style("my-second-bucket", region, fake_credentials());
         let path = "/my-second/path";
         let request = AttoRequest::new(&bucket, path, Command::GetObject);
 

--- a/s3/src/bucket_ops.rs
+++ b/s3/src/bucket_ops.rs
@@ -1,5 +1,4 @@
 use crate::{Bucket, Region};
-use anyhow::Result;
 
 /// [AWS Documentation](https://docs.aws.amazon.com/AmazonS3/latest/dev/acl-overview.html#CannedACL)
 #[allow(dead_code)]
@@ -119,7 +118,7 @@ impl BucketConfiguration {
         }
     }
 
-    pub fn add_headers(&self, headers: &mut HeaderMap) -> Result<()> {
+    pub fn add_headers(&self, headers: &mut HeaderMap) {
         headers.insert(
             HeaderName::from_static("x-amz-acl"),
             self.acl.to_string().parse().unwrap(),
@@ -160,7 +159,6 @@ impl BucketConfiguration {
                 acl_list(value).parse().unwrap(),
             );
         }
-        Ok(())
     }
 }
 

--- a/s3/src/errors.rs
+++ b/s3/src/errors.rs
@@ -1,0 +1,48 @@
+use thiserror::Error;
+
+#[derive(Error, Debug)]
+pub enum PresignError {
+    #[error("invalid key length")]
+    InvalidKeylength,
+    #[error("url parsing failed: {0}")]
+    InvalidUrl(#[from] url::ParseError),
+    #[error("Max expiration for presigned URLs is one week, or 604.800 seconds, got {0} instead")]
+    ExpirationOverflow(u32),
+}
+
+impl From<crypto_mac::InvalidKeyLength> for PresignError {
+    fn from(_: crypto_mac::InvalidKeyLength) -> PresignError {
+        PresignError::InvalidKeylength
+    }
+}
+
+#[derive(Error, Debug)]
+pub enum ResponseError {
+    #[error("invalid key length when signing the request")]
+    SigningError,
+    #[error("status code {0} indicates that the request failed:\n{1:?}")]
+    /// StatusCode contains the returned HTTP status code along with the body of the response
+    StatusCode(u16, Option<String>),
+    #[error("I/O error: {0}")]
+    IoError(#[from] std::io::Error),
+    #[error("String conversion failed: {0}")]
+    InvalidHeaderString(#[from] http::header::ToStrError),
+    #[error("UTF-8 conversion error: {0}")]
+    InvalidUtf8(#[from] std::string::FromUtf8Error),
+    #[error("Deserialization error: {0}")]
+    ImpossibleDeserialization(#[from] serde_xml_rs::Error),
+
+    #[cfg(feature = "with-tokio")]
+    #[error("failed request {0}")]
+    RequestError(#[from] reqwest::Error),
+
+    #[cfg(any(feature = "blocking", feature = "sync"))]
+    #[error("failed request {0}")]
+    RequestError(#[from] attohttpc::Error),
+}
+
+impl From<crypto_mac::InvalidKeyLength> for ResponseError {
+    fn from(_: crypto_mac::InvalidKeyLength) -> ResponseError {
+        ResponseError::SigningError
+    }
+}

--- a/s3/src/lib.rs
+++ b/s3/src/lib.rs
@@ -17,6 +17,7 @@ pub mod bucket;
 pub mod bucket_ops;
 pub mod command;
 pub mod deserializer;
+pub mod errors;
 #[cfg(feature = "with-tokio")]
 pub mod request;
 pub mod serde_types;

--- a/s3/src/signing.rs
+++ b/s3/src/signing.rs
@@ -11,8 +11,6 @@ use sha2::{Digest, Sha256};
 use url::Url;
 
 use crate::region::Region;
-use anyhow::anyhow;
-use anyhow::Result;
 use http::HeaderMap;
 
 const SHORT_DATE: &str = "%Y%m%d";
@@ -155,18 +153,15 @@ pub fn signing_key(
     secret_key: &str,
     region: &Region,
     service: &str,
-) -> Result<Vec<u8>> {
+) -> Result<Vec<u8>, crypto_mac::InvalidKeyLength> {
     let secret = format!("AWS4{}", secret_key);
-    let mut date_hmac = HmacSha256::new_varkey(secret.as_bytes()).map_err(|e| anyhow! {"{}",e})?;
+    let mut date_hmac = HmacSha256::new_varkey(secret.as_bytes())?;
     date_hmac.update(datetime.format(SHORT_DATE).to_string().as_bytes());
-    let mut region_hmac =
-        HmacSha256::new_varkey(&date_hmac.finalize().into_bytes()).map_err(|e| anyhow! {"{}",e})?;
+    let mut region_hmac = HmacSha256::new_varkey(&date_hmac.finalize().into_bytes())?;
     region_hmac.update(region.to_string().as_bytes());
-    let mut service_hmac = HmacSha256::new_varkey(&region_hmac.finalize().into_bytes())
-        .map_err(|e| anyhow! {"{}",e})?;
+    let mut service_hmac = HmacSha256::new_varkey(&region_hmac.finalize().into_bytes())?;
     service_hmac.update(service.as_bytes());
-    let mut signing_hmac = HmacSha256::new_varkey(&service_hmac.finalize().into_bytes())
-        .map_err(|e| anyhow! {"{}",e})?;
+    let mut signing_hmac = HmacSha256::new_varkey(&service_hmac.finalize().into_bytes())?;
     signing_hmac.update(b"aws4_request");
     Ok(signing_hmac.finalize().into_bytes().to_vec())
 }
@@ -196,7 +191,7 @@ pub fn authorization_query_params_no_sig(
     expires: u32,
     custom_headers: Option<&HeaderMap>,
     token: Option<&str>,
-) -> Result<String> {
+) -> String {
     let credentials = uri_encode(
         &format!("{}/{}", access_key, scope_string(datetime, region)),
         true,
@@ -231,7 +226,7 @@ pub fn authorization_query_params_no_sig(
         ))
     }
 
-    Ok(query_params)
+    query_params
 }
 
 #[cfg(test)]
@@ -319,7 +314,7 @@ mod tests {
         let key = "wJalrXUtnFEMI/K7MDENG+bPxRfiCYEXAMPLEKEY";
         let expected = "c4afb1cc5771d871763a393e44b703571b55cc28424d1a5e86da6ed3c154a4b9";
         let datetime = Utc.ymd(2015, 8, 30).and_hms(0, 0, 0);
-        let signature = signing_key(&datetime, key, &"us-east-1".parse().unwrap(), "iam").unwrap();
+        let signature = signing_key(&datetime, key, &Region::from("us-east-1"), "iam").unwrap();
         assert_eq!(expected, hex::encode(signature));
     }
 
@@ -364,12 +359,12 @@ mod tests {
         assert_eq!(EXPECTED_CANONICAL_REQUEST, canonical);
 
         let datetime = Utc.ymd(2013, 5, 24).and_hms(0, 0, 0);
-        let string_to_sign = string_to_sign(&datetime, &"us-east-1".parse().unwrap(), &canonical);
+        let string_to_sign = string_to_sign(&datetime, &Region::from("us-east-1"), &canonical);
         assert_eq!(EXPECTED_STRING_TO_SIGN, string_to_sign);
 
         let expected = "f0e8bdb87c964420e857bd35b5d6ed310bd44f0170aba48dd91039c6036bdb41";
         let secret = "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY";
-        let signing_key = signing_key(&datetime, secret, &"us-east-1".parse().unwrap(), "s3");
+        let signing_key = signing_key(&datetime, secret, &Region::from("us-east-1"), "s3");
         let mut hmac = Hmac::<Sha256>::new_varkey(&signing_key.unwrap()).unwrap();
         hmac.update(string_to_sign.as_bytes());
         assert_eq!(expected, hex::encode(hmac.finalize().into_bytes()));

--- a/s3/src/utils.rs
+++ b/s3/src/utils.rs
@@ -1,7 +1,6 @@
 use std::str::FromStr;
 
 use crate::{bucket::CHUNK_SIZE, serde_types::HeadObjectResult};
-use anyhow::Result;
 
 #[cfg(feature = "with-async-std")]
 use async_std::fs::File;
@@ -34,7 +33,7 @@ use tokio::io::{AsyncRead, AsyncReadExt};
 /// }
 /// ```
 #[cfg(any(feature = "tokio", feature = "async-std"))]
-pub async fn etag_for_path(path: impl AsRef<Path>) -> Result<String> {
+pub async fn etag_for_path(path: impl AsRef<Path>) -> Result<String, std::io::Error> {
     let mut file = File::open(path).await?;
     let mut digests = Vec::new();
     let mut chunks = 0;
@@ -65,7 +64,7 @@ pub async fn etag_for_path(path: impl AsRef<Path>) -> Result<String> {
 /// println!("{}", etag);
 /// ```
 #[cfg(feature = "sync")]
-pub fn etag_for_path(path: impl AsRef<Path>) -> Result<String> {
+pub fn etag_for_path(path: impl AsRef<Path>) -> Result<String, std::io::Error> {
     let mut file = File::open(path)?;
     let mut digests = Vec::new();
     let mut chunks = 0;
@@ -88,7 +87,7 @@ pub fn etag_for_path(path: impl AsRef<Path>) -> Result<String> {
 }
 
 #[cfg(any(feature = "tokio", feature = "async-std"))]
-pub async fn read_chunk<R: AsyncRead + Unpin>(reader: &mut R) -> Result<Vec<u8>> {
+pub async fn read_chunk<R: AsyncRead + Unpin>(reader: &mut R) -> Result<Vec<u8>, std::io::Error> {
     let mut chunk = Vec::with_capacity(CHUNK_SIZE);
     let mut take = reader.take(CHUNK_SIZE as u64);
     take.read_to_end(&mut chunk).await?;
@@ -97,7 +96,7 @@ pub async fn read_chunk<R: AsyncRead + Unpin>(reader: &mut R) -> Result<Vec<u8>>
 }
 
 #[cfg(feature = "sync")]
-pub fn read_chunk<R: Read>(reader: &mut R) -> Result<Vec<u8>> {
+pub fn read_chunk<R: Read>(reader: &mut R) -> Result<Vec<u8>, std::io::Error> {
     let mut chunk = Vec::with_capacity(CHUNK_SIZE);
     let mut take = reader.take(CHUNK_SIZE as u64);
     take.read_to_end(&mut chunk)?;


### PR DESCRIPTION
Following discussion at #164, this PR replaces `anyhow` with `thiserror` to make errors more explicit, comparable, and so on. The goal is for consumers of this library to be able to extract information about errors without having to downcast anyhow errors, and thus to have more granularity to filter the errors and/or understand the issue at hand.


As an important note, this is not API compatible with the current 0.27 branch but I guess this is acceptable in a beta 0.x release.
I also added the sync tests to the Makefile so that it is executed when calling `make ci`.