### PR TITLE
Add support for the older ListObjects API

### DIFF
--- a/s3/src/command.rs
+++ b/s3/src/command.rs
@@ -46,13 +46,20 @@ pub enum Command<'a> {
         tags: &'a str,
     },
 
-    ListBucket {
+    ListObjects {
+        prefix: String,
+        delimiter: Option<String>,
+        marker: Option<String>,
+        max_keys: Option<usize>,
+    },
+    ListObjectsV2 {
         prefix: String,
         delimiter: Option<String>,
         continuation_token: Option<String>,
         start_after: Option<String>,
         max_keys: Option<usize>,
     },
+
     GetBucketLocation,
     PresignGet {
         expiry_secs: u32,
@@ -85,7 +92,8 @@ impl<'a> Command<'a> {
         match *self {
             Command::GetObject
             | Command::GetObjectRange { .. }
-            | Command::ListBucket { .. }
+            | Command::ListObjects { .. }
+            | Command::ListObjectsV2 { .. }
             | Command::GetBucketLocation
             | Command::GetObjectTagging
             | Command::PresignGet { .. } => HttpMethod::Get,

--- a/s3/src/serde_types.rs
+++ b/s3/src/serde_types.rs
@@ -31,7 +31,7 @@ pub struct Object {
     pub e_tag: String,
     #[serde(rename = "StorageClass")]
     /// STANDARD | STANDARD_IA | REDUCED_REDUNDANCY | GLACIER
-    pub storage_class: String,
+    pub storage_class: Option<String>,
     #[serde(rename = "Key")]
     /// The object's key
     pub key: String,
@@ -119,30 +119,27 @@ pub struct BucketLocationResult {
 }
 
 /// The parsed result of a s3 bucket listing
+///
+/// This accepts the ListBucketResult format returned for both ListObjects and ListObjectsV2
 #[derive(Deserialize, Debug, Clone)]
 pub struct ListBucketResult {
     #[serde(rename = "Name")]
     /// Name of the bucket.
     pub name: String,
-    #[serde(rename = "NextMarker")]
-    /// When the response is truncated (that is, the IsTruncated element value in the response
-    /// is true), you can use the key name in this field as a marker in the subsequent request
-    /// to get next set of objects. Amazon S3 lists objects in UTF-8 character encoding in
-    /// lexicographical order.
-    pub next_marker: Option<String>,
     #[serde(rename = "Delimiter")]
     /// A delimiter is a character you use to group keys.
     pub delimiter: Option<String>,
     #[serde(rename = "MaxKeys")]
     /// Sets the maximum number of keys returned in the response body.
-    pub max_keys: i32,
+    pub max_keys: Option<i32>,
     #[serde(rename = "Prefix")]
     /// Limits the response to keys that begin with the specified prefix.
     pub prefix: String,
-    #[serde(rename = "Marker")]
-    /// Indicates where in the bucket listing begins. Marker is included in the response if
+    #[serde(rename = "ContinuationToken")]  // for ListObjectsV2 request
+    #[serde(alias = "Marker")]  // for ListObjects request
+    /// Indicates where in the bucket listing begins. It is included in the response if
     /// it was sent with the request.
-    pub marker: Option<String>,
+    pub continuation_token: Option<String>,
     #[serde(rename = "EncodingType")]
     /// Specifies the encoding method to used
     pub encoding_type: Option<String>,
@@ -153,8 +150,14 @@ pub struct ListBucketResult {
     ///  Specifies whether (true) or not (false) all of the results were returned.
     ///  If the number of results exceeds that specified by MaxKeys, all of the results
     ///  might not be returned.
+
+    /// When the response is truncated (that is, the IsTruncated element value in the response
+    /// is true), you can use the key name in in 'next_continuation_token' as a marker in the
+    /// subsequent request to get next set of objects. Amazon S3 lists objects in UTF-8 character
+    /// encoding in lexicographical order.
     pub is_truncated: bool,
-    #[serde(rename = "NextContinuationToken", default)]
+    #[serde(rename = "NextContinuationToken", default)]  // for ListObjectsV2 request
+    #[serde(alias = "NextMarker")]  // for ListObjects request
     pub next_continuation_token: Option<String>,
     #[serde(rename = "Contents", default)]
     /// Metadata about each object returned.


### PR DESCRIPTION
Google Cloud Storage doesn't support the newer ListObjectsV2 call.

I don't have accounts with all the supported providers, so I couldn't run all the tests. I did run the GCS test, and I also tested that the ListObjectsV2 codepath still works againt a local Minio server.