### PR TITLE
Add Tag impl with key and value methods

### DIFF
--- a/s3/src/bucket.rs
+++ b/s3/src/bucket.rs
@@ -55,13 +55,13 @@ pub struct Tag {
 }
 
 impl Tag {
-   pub fn key(&self) -> String {
+    pub fn key(&self) -> String {
         self.key.to_owned()
-   }
+    }
 
-   pub fn value(&self) -> String {
+    pub fn value(&self) -> String {
         self.value.to_owned()
-   }
+    }
 }
 
 /// Instantiate an existing Bucket
@@ -2151,10 +2151,7 @@ mod test {
     fn test_tag_has_key_and_value_functions() {
         let key = "key".to_owned();
         let value = "value".to_owned();
-        let tag = Tag {
-            key,
-            value,
-        };
+        let tag = Tag { key, value };
         assert_eq!["key", tag.key()];
         assert_eq!["value", tag.value()];
     }

--- a/s3/src/bucket.rs
+++ b/s3/src/bucket.rs
@@ -54,6 +54,16 @@ pub struct Tag {
     value: String,
 }
 
+impl Tag {
+   pub fn key(&self) -> String {
+        self.key.to_owned()
+   }
+
+   pub fn value(&self) -> String {
+        self.value.to_owned()
+   }
+}
+
 /// Instantiate an existing Bucket
 ///
 /// # Example
@@ -2135,5 +2145,17 @@ mod test {
 
         let response_code = response.bucket.delete().await.unwrap();
         assert!(response_code < 300);
+    }
+
+    #[test]
+    fn test_tag_has_key_and_value_functions() {
+        let key = "key".to_owned();
+        let value = "value".to_owned();
+        let tag = Tag {
+            key,
+            value,
+        };
+        assert_eq!["key", tag.key()];
+        assert_eq!["value", tag.value()];
     }
 }


### PR DESCRIPTION
There was no way to access these from the object in the crate, so I
added them back.

Fixes #185