### PR TITLE
Re-introduce proper error handling with thiserror

### DIFF
--- a/aws-creds/Cargo.toml
+++ b/aws-creds/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "aws-creds"
-version = "0.26.2"
+version = "0.27.0"
 authors = ["Drazen Urch"]
 description = "Tiny Rust library for working with Amazon IAM credential,s, supports `s3` crate"
 repository = "https://github.com/durch/rust-s3"
@@ -15,7 +15,7 @@ name = "awscreds"
 path = "src/lib.rs"
 
 [dependencies]
-anyhow = "1.0"
+thiserror = "1.0"
 dirs = "4"
 rust-ini = "0.17"
 attohttpc = { version = "0.17", default-features = false, features = ["json"] }

--- a/aws-region/Cargo.toml
+++ b/aws-region/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "aws-region"
-version = "0.23.2"
+version = "0.24.0"
 authors = ["Drazen Urch"]
 description = "Tiny Rust library for working with Amazon AWS regions, supports `s3` crate"
 repository = "https://github.com/durch/rust-s3"
@@ -13,6 +13,3 @@ edition = "2018"
 [lib]
 name = "awsregion"
 path = "src/lib.rs"
-
-[dependencies]
-anyhow = "1.0"

--- a/aws-region/src/region.rs
+++ b/aws-region/src/region.rs
@@ -3,8 +3,6 @@
 use std::fmt;
 use std::str::{self, FromStr};
 
-use anyhow::Result;
-
 /// AWS S3 [region identifier](https://docs.aws.amazon.com/general/latest/gr/rande.html#s3_region),
 /// passing in custom values is also possible, in that case it is up to you to pass a valid endpoint,
 /// otherwise boom will happen :)
@@ -15,7 +13,7 @@ use anyhow::Result;
 /// use awsregion::Region;
 ///
 /// // Parse from a string
-/// let region: Region = "us-east-1".parse().unwrap();
+/// let region: Region = Region::from("us-east-1");
 ///
 /// // Choose region directly
 /// let region = Region::EuWest2;
@@ -128,46 +126,44 @@ impl fmt::Display for Region {
     }
 }
 
-impl FromStr for Region {
-    type Err = anyhow::Error;
-
-    fn from_str(s: &str) -> Result<Self> {
+impl From<&str> for Region {
+    fn from(s: &str) -> Region {
         use self::Region::*;
         match s {
-            "us-east-1" => Ok(UsEast1),
-            "us-east-2" => Ok(UsEast2),
-            "us-west-1" => Ok(UsWest1),
-            "us-west-2" => Ok(UsWest2),
-            "ca-central-1" => Ok(CaCentral1),
-            "ap-south-1" => Ok(ApSouth1),
-            "ap-northeast-1" => Ok(ApNortheast1),
-            "ap-northeast-2" => Ok(ApNortheast2),
-            "ap-northeast-3" => Ok(ApNortheast3),
-            "ap-southeast-1" => Ok(ApSoutheast1),
-            "ap-southeast-2" => Ok(ApSoutheast2),
-            "cn-north-1" => Ok(CnNorth1),
-            "cn-northwest-1" => Ok(CnNorthwest1),
-            "eu-north-1" => Ok(EuNorth1),
-            "eu-central-1" => Ok(EuCentral1),
-            "eu-west-1" => Ok(EuWest1),
-            "eu-west-2" => Ok(EuWest2),
-            "eu-west-3" => Ok(EuWest3),
-            "sa-east-1" => Ok(SaEast1),
-            "me-south-1" => Ok(MeSouth1),
-            "nyc3" => Ok(DoNyc3),
-            "ams3" => Ok(DoAms3),
-            "sgp1" => Ok(DoSgp1),
-            "fra1" => Ok(DoFra1),
-            "yandex" => Ok(Yandex),
-            "ru-central1" => Ok(Yandex),
-            "wa-us-east-1" => Ok(WaUsEast1),
-            "wa-us-east-2" => Ok(WaUsEast2),
-            "wa-us-west-1" => Ok(WaUsWest1),
-            "wa-eu-central-1" => Ok(WaEuCentral1),
-            x => Ok(Custom {
+            "us-east-1" => UsEast1,
+            "us-east-2" => UsEast2,
+            "us-west-1" => UsWest1,
+            "us-west-2" => UsWest2,
+            "ca-central-1" => CaCentral1,
+            "ap-south-1" => ApSouth1,
+            "ap-northeast-1" => ApNortheast1,
+            "ap-northeast-2" => ApNortheast2,
+            "ap-northeast-3" => ApNortheast3,
+            "ap-southeast-1" => ApSoutheast1,
+            "ap-southeast-2" => ApSoutheast2,
+            "cn-north-1" => CnNorth1,
+            "cn-northwest-1" => CnNorthwest1,
+            "eu-north-1" => EuNorth1,
+            "eu-central-1" => EuCentral1,
+            "eu-west-1" => EuWest1,
+            "eu-west-2" => EuWest2,
+            "eu-west-3" => EuWest3,
+            "sa-east-1" => SaEast1,
+            "me-south-1" => MeSouth1,
+            "nyc3" => DoNyc3,
+            "ams3" => DoAms3,
+            "sgp1" => DoSgp1,
+            "fra1" => DoFra1,
+            "yandex" => Yandex,
+            "ru-central1" => Yandex,
+            "wa-us-east-1" => WaUsEast1,
+            "wa-us-east-2" => WaUsEast2,
+            "wa-us-west-1" => WaUsWest1,
+            "wa-eu-central-1" => WaEuCentral1,
+            x => Custom {
                 region: x.to_string(),
                 endpoint: x.to_string(),
-            }),
+            },
         }
     }
 }
@@ -239,7 +235,7 @@ fn yandex_object_storage() {
         region: "ru-central1".to_string(),
     };
 
-    let yandex_region = "ru-central1".parse::<Region>().unwrap();
+    let yandex_region = Region::from("ru-central1");
 
     assert_eq!(yandex.endpoint(), yandex_region.endpoint());
 

--- a/s3/Cargo.toml
+++ b/s3/Cargo.toml
@@ -22,8 +22,8 @@ path = "src/lib.rs"
 async-std = { version = "1", optional = true }
 async-trait = "0.1"
 attohttpc = { version = "0.17", optional = true, default-features = false }
-aws-creds = { version = "0.26", default-features = false }
-aws-region = "0.23"
+aws-creds = { path = "../aws-creds", default-features = false }
+aws-region = { path = "../aws-region" }
 base64 = "0.13.0"
 cfg-if = "1"
 chrono = "0.4"
@@ -40,7 +40,7 @@ serde = "1"
 serde_derive = "1"
 serde-xml-rs = "0.5"
 sha2 = "0.9"
-anyhow = "1.0"
+thiserror = "1.0"
 surf = { version = "2", optional = true, default-features = false, features = ["h1-client-rustls"] }
 tokio = { version = "1", features = ["io-util"], optional = true, default-features = false }
 tokio-stream = "0.1"
@@ -68,3 +68,4 @@ tokio = { version = "1", features = ["rt", "rt-multi-thread", "macros"] }
 async-std = { version = "1", features = ["attributes"] }
 uuid = { version = "0.8", features = ["v4"] }
 env_logger = "0.9"
+anyhow = "1.0"

--- a/s3/Makefile
+++ b/s3/Makefile
@@ -9,7 +9,7 @@ sync-clippy: sync-nativetls-clippy sync-nossl-clippy sync-rustlstls-clippy
 
 # tokio
 tokio: tokio-nativetls tokio-nossl tokio-noverify tokio-rustlstls
-tokio-not-ignored: tokio-nativetls-test-not-ignored tokio-nossl-test-not-ignored tokio-noverify-test-not-ignored tokio-rustlstls-test-not-ignored
+tokio-not-ignored: tokio-nativetls-test-not-ignored tokio-nossl-test-not-ignored tokio-noverify-test-not-ignored tokio-rustlstls-test-not-ignored sync-nativetls-test-not-ignored sync-rustlstls-test-not-ignored
 
 tokio-nativetls: tokio-nativetls-clippy tokio-nativetls-test tokio-nativetls-blocking-test-ignored
 tokio-nativetls-clippy:
@@ -57,17 +57,21 @@ async-std-test-blocking-ignored:
 # sync
 sync-nativetls: sync-nativetls-clippy sync-nativetls-test
 sync-nativetls-clippy:
-	cargo clippy --no-default-features --features sync --features sync-native-tls -- -D warnings
-sync-nativetls-test: sync-nativetls-test-ignored
+	cargo clippy --no-default-features --features sync-native-tls -- -D warnings
+sync-nativetls-test: sync-nativetls-test-ignored sync-nativetls-test-not-ignored
 sync-nativetls-test-ignored:
-	cargo test --no-default-features --features sync --features sync-native-tls -- --ignored
+	cargo test --no-default-features --features sync-native-tls -- --ignored
+sync-nativetls-test-not-ignored:
+	cargo test --no-default-features --features sync-native-tls
 
 sync-rustlstls: sync-rustlstls-clippy sync-rustlstls-test
 sync-rustlstls-clippy:
-	cargo clippy --no-default-features --features sync --features sync-rustls-tls -- -D warnings
-sync-rustlstls-test: sync-rustlstls-test-ignored
+	cargo clippy --no-default-features --features sync-rustls-tls -- -D warnings
+sync-rustlstls-test: sync-rustlstls-test-ignored sync-rustlstls-test-not-ignored
 sync-rustlstls-test-ignored:
-	cargo test --no-default-features --features sync --features sync-rustls-tls -- --ignored
+	cargo test --no-default-features --features sync-rustls-tls -- --ignored
+sync-rustlstls-test-not-ignored:
+	cargo test --no-default-features --features sync-rustls-tls
 
 sync-nossl: sync-nossl-clippy
 sync-nossl-clippy:

--- a/s3/src/bucket_ops.rs
+++ b/s3/src/bucket_ops.rs
@@ -1,5 +1,4 @@
 use crate::{Bucket, Region};
-use anyhow::Result;
 
 /// [AWS Documentation](https://docs.aws.amazon.com/AmazonS3/latest/dev/acl-overview.html#CannedACL)
 #[allow(dead_code)]
@@ -119,7 +118,7 @@ impl BucketConfiguration {
         }
     }
 
-    pub fn add_headers(&self, headers: &mut HeaderMap) -> Result<()> {
+    pub fn add_headers(&self, headers: &mut HeaderMap) {
         headers.insert(
             HeaderName::from_static("x-amz-acl"),
             self.acl.to_string().parse().unwrap(),
@@ -160,7 +159,6 @@ impl BucketConfiguration {
                 acl_list(value).parse().unwrap(),
             );
         }
-        Ok(())
     }
 }
 

--- a/s3/src/errors.rs
+++ b/s3/src/errors.rs
@@ -1,0 +1,48 @@
+use thiserror::Error;
+
+#[derive(Error, Debug)]
+pub enum PresignError {
+    #[error("invalid key length")]
+    InvalidKeylength,
+    #[error("url parsing failed: {0}")]
+    InvalidUrl(#[from] url::ParseError),
+    #[error("Max expiration for presigned URLs is one week, or 604.800 seconds, got {0} instead")]
+    ExpirationOverflow(u32),
+}
+
+impl From<hmac::crypto_mac::InvalidKeyLength> for PresignError {
+    fn from(_: hmac::crypto_mac::InvalidKeyLength) -> PresignError {
+        PresignError::InvalidKeylength
+    }
+}
+
+#[derive(Error, Debug)]
+pub enum ResponseError {
+    #[error("invalid key length when signing the request")]
+    SigningError,
+    #[error("status code {0} indicates that the request failed:\n{1:?}")]
+    /// StatusCode contains the returned HTTP status code along with the body of the response
+    StatusCode(u16, Option<String>),
+    #[error("I/O error: {0}")]
+    IoError(#[from] std::io::Error),
+    #[error("String conversion failed: {0}")]
+    InvalidHeaderString(#[from] http::header::ToStrError),
+    #[error("UTF-8 conversion error: {0}")]
+    InvalidUtf8(#[from] std::string::FromUtf8Error),
+    #[error("Deserialization error: {0}")]
+    ImpossibleDeserialization(#[from] serde_xml_rs::Error),
+
+    #[cfg(feature = "with-tokio")]
+    #[error("failed request {0}")]
+    RequestError(#[from] reqwest::Error),
+
+    #[cfg(any(feature = "blocking", feature = "sync"))]
+    #[error("failed request {0}")]
+    RequestError(#[from] attohttpc::Error),
+}
+
+impl From<hmac::crypto_mac::InvalidKeyLength> for ResponseError {
+    fn from(_: hmac::crypto_mac::InvalidKeyLength) -> ResponseError {
+        ResponseError::SigningError
+    }
+}

--- a/s3/src/lib.rs
+++ b/s3/src/lib.rs
@@ -18,6 +18,7 @@ pub mod bucket;
 pub mod bucket_ops;
 pub mod command;
 pub mod deserializer;
+pub mod errors;
 #[cfg(feature = "with-tokio")]
 pub mod request;
 pub mod serde_types;

--- a/s3/src/request_trait.rs
+++ b/s3/src/request_trait.rs
@@ -7,10 +7,9 @@ use url::Url;
 
 use crate::bucket::Bucket;
 use crate::command::Command;
+use crate::errors::{PresignError, ResponseError};
 use crate::signing;
 use crate::LONG_DATE;
-use anyhow::anyhow;
-use anyhow::Result;
 use http::header::{
     HeaderName, ACCEPT, AUTHORIZATION, CONTENT_LENGTH, CONTENT_TYPE, DATE, HOST, RANGE,
 };
@@ -21,16 +20,19 @@ pub trait Request {
     type Response;
     type HeaderMap;
 
-    async fn response(&self) -> Result<Self::Response>;
-    async fn response_data(&self, etag: bool) -> Result<(Vec<u8>, u16)>;
-    async fn response_data_to_writer<T: Write + Send>(&self, writer: &mut T) -> Result<u16>;
-    async fn response_header(&self) -> Result<(Self::HeaderMap, u16)>;
+    async fn response(&self) -> Result<Self::Response, ResponseError>;
+    async fn response_data(&self, etag: bool) -> Result<(Vec<u8>, u16), ResponseError>;
+    async fn response_data_to_writer<T: Write + Send>(
+        &self,
+        writer: &mut T,
+    ) -> Result<u16, ResponseError>;
+    async fn response_header(&self) -> Result<(Self::HeaderMap, u16), ResponseError>;
     fn datetime(&self) -> DateTime<Utc>;
     fn bucket(&self) -> Bucket;
     fn command(&self) -> Command;
     fn path(&self) -> String;
 
-    fn signing_key(&self) -> Result<Vec<u8>> {
+    fn signing_key(&self) -> Result<Vec<u8>, hmac::crypto_mac::InvalidKeyLength> {
         signing::signing_key(
             &self.datetime(),
             &self
@@ -76,7 +78,7 @@ pub trait Request {
         self.bucket().host()
     }
 
-    fn presigned(&self) -> Result<String> {
+    fn presigned(&self) -> Result<String, PresignError> {
         let expiry = match self.command() {
             Command::PresignGet { expiry_secs } => expiry_secs,
             Command::PresignPut { expiry_secs, .. } => expiry_secs,
@@ -84,26 +86,23 @@ pub trait Request {
             _ => unreachable!(),
         };
 
+        let mut extra_headers = None;
         #[allow(clippy::collapsible_match)]
         if let Command::PresignPut { custom_headers, .. } = self.command() {
-            if let Some(custom_headers) = custom_headers {
-                let authorization = self.presigned_authorization(Some(&custom_headers))?;
-                return Ok(format!(
-                    "{}&X-Amz-Signature={}",
-                    self.presigned_url_no_sig(expiry, Some(&custom_headers))?,
-                    authorization
-                ));
-            }
+            extra_headers = custom_headers;
         }
 
         Ok(format!(
             "{}&X-Amz-Signature={}",
-            self.presigned_url_no_sig(expiry, None)?,
-            self.presigned_authorization(None)?
+            self.presigned_url_no_sig(expiry, extra_headers.as_ref())?,
+            self.presigned_authorization(extra_headers.as_ref())?
         ))
     }
 
-    fn presigned_authorization(&self, custom_headers: Option<&HeaderMap>) -> Result<String> {
+    fn presigned_authorization(
+        &self,
+        custom_headers: Option<&HeaderMap>,
+    ) -> Result<String, PresignError> {
         let mut headers = HeaderMap::new();
         let host_header = self.host_header();
         headers.insert(HOST, host_header.parse().unwrap());
@@ -114,15 +113,14 @@ pub trait Request {
         }
         let canonical_request = self.presigned_canonical_request(&headers)?;
         let string_to_sign = self.string_to_sign(&canonical_request);
-        let mut hmac = signing::HmacSha256::new_from_slice(&self.signing_key()?)
-            .map_err(|e| anyhow! {"{}",e})?;
+        let mut hmac = signing::HmacSha256::new_from_slice(&self.signing_key()?)?;
         hmac.update(string_to_sign.as_bytes());
         let signature = hex::encode(hmac.finalize().into_bytes());
         // let signed_header = signing::signed_header_string(&headers);
         Ok(signature)
     }
 
-    fn presigned_canonical_request(&self, headers: &HeaderMap) -> Result<String> {
+    fn presigned_canonical_request(&self, headers: &HeaderMap) -> Result<String, url::ParseError> {
         let expiry = match self.command() {
             Command::PresignGet { expiry_secs } => expiry_secs,
             Command::PresignPut { expiry_secs, .. } => expiry_secs,
@@ -130,34 +128,33 @@ pub trait Request {
             _ => unreachable!(),
         };
 
+        let mut extra_headers = None;
         #[allow(clippy::collapsible_match)]
         if let Command::PresignPut { custom_headers, .. } = self.command() {
-            if let Some(custom_headers) = custom_headers {
-                return Ok(signing::canonical_request(
-                    &self.command().http_verb().to_string(),
-                    &self.presigned_url_no_sig(expiry, Some(&custom_headers))?,
-                    headers,
-                    "UNSIGNED-PAYLOAD",
-                ));
-            }
+            extra_headers = custom_headers;
         }
 
         Ok(signing::canonical_request(
             &self.command().http_verb().to_string(),
-            &self.presigned_url_no_sig(expiry, None)?,
+            &self.presigned_url_no_sig(expiry, extra_headers.as_ref())?,
             headers,
             "UNSIGNED-PAYLOAD",
         ))
     }
 
-    fn presigned_url_no_sig(&self, expiry: u32, custom_headers: Option<&HeaderMap>) -> Result<Url> {
+    fn presigned_url_no_sig(
+        &self,
+        expiry: u32,
+        custom_headers: Option<&HeaderMap>,
+    ) -> Result<Url, url::ParseError> {
         let bucket = self.bucket();
         let token = if let Some(security_token) = bucket.security_token() {
             Some(security_token)
         } else {
             bucket.session_token()
         };
-        let url = Url::parse(&format!(
+
+        Url::parse(&format!(
             "{}{}",
             self.url(),
             &signing::authorization_query_params_no_sig(
@@ -167,10 +164,8 @@ pub trait Request {
                 expiry,
                 custom_headers,
                 token
-            )?
-        ))?;
-
-        Ok(url)
+            )
+        ))
     }
 
     fn url(&self) -> Url {
@@ -283,11 +278,13 @@ pub trait Request {
         )
     }
 
-    fn authorization(&self, headers: &HeaderMap) -> Result<String> {
+    fn authorization(
+        &self,
+        headers: &HeaderMap,
+    ) -> Result<String, hmac::crypto_mac::InvalidKeyLength> {
         let canonical_request = self.canonical_request(headers);
         let string_to_sign = self.string_to_sign(&canonical_request);
-        let mut hmac = signing::HmacSha256::new_from_slice(&self.signing_key()?)
-            .map_err(|e| anyhow! {"{}",e})?;
+        let mut hmac = signing::HmacSha256::new_from_slice(&self.signing_key()?)?;
         hmac.update(string_to_sign.as_bytes());
         let signature = hex::encode(hmac.finalize().into_bytes());
         let signed_header = signing::signed_header_string(headers);
@@ -300,7 +297,7 @@ pub trait Request {
         ))
     }
 
-    fn headers(&self) -> Result<HeaderMap> {
+    fn headers(&self) -> Result<HeaderMap, hmac::crypto_mac::InvalidKeyLength> {
         // Generate this once, but it's used in more than one place.
         let sha256 = self.command().sha256();
 
@@ -398,7 +395,7 @@ pub trait Request {
 
             headers.insert(RANGE, range.parse().unwrap());
         } else if let Command::CreateBucket { ref config } = self.command() {
-            config.add_headers(&mut headers)?;
+            config.add_headers(&mut headers);
         }
 
         // This must be last, as it signs the other headers, omitted if no secret key is provided

--- a/s3/src/utils.rs
+++ b/s3/src/utils.rs
@@ -1,7 +1,6 @@
 use std::str::FromStr;
 
 use crate::{bucket::CHUNK_SIZE, serde_types::HeadObjectResult};
-use anyhow::Result;
 
 #[cfg(feature = "with-async-std")]
 use async_std::fs::File;
@@ -34,7 +33,7 @@ use tokio::io::{AsyncRead, AsyncReadExt};
 /// }
 /// ```
 #[cfg(any(feature = "tokio", feature = "async-std"))]
-pub async fn etag_for_path(path: impl AsRef<Path>) -> Result<String> {
+pub async fn etag_for_path(path: impl AsRef<Path>) -> Result<String, std::io::Error> {
     let mut file = File::open(path).await?;
     let mut digests = Vec::new();
     let mut chunks = 0;
@@ -65,7 +64,7 @@ pub async fn etag_for_path(path: impl AsRef<Path>) -> Result<String> {
 /// println!("{}", etag);
 /// ```
 #[cfg(feature = "sync")]
-pub fn etag_for_path(path: impl AsRef<Path>) -> Result<String> {
+pub fn etag_for_path(path: impl AsRef<Path>) -> Result<String, std::io::Error> {
     let mut file = File::open(path)?;
     let mut digests = Vec::new();
     let mut chunks = 0;
@@ -88,7 +87,7 @@ pub fn etag_for_path(path: impl AsRef<Path>) -> Result<String> {
 }
 
 #[cfg(any(feature = "tokio", feature = "async-std"))]
-pub async fn read_chunk<R: AsyncRead + Unpin>(reader: &mut R) -> Result<Vec<u8>> {
+pub async fn read_chunk<R: AsyncRead + Unpin>(reader: &mut R) -> Result<Vec<u8>, std::io::Error> {
     let mut chunk = Vec::with_capacity(CHUNK_SIZE);
     let mut take = reader.take(CHUNK_SIZE as u64);
     take.read_to_end(&mut chunk).await?;
@@ -97,7 +96,7 @@ pub async fn read_chunk<R: AsyncRead + Unpin>(reader: &mut R) -> Result<Vec<u8>>
 }
 
 #[cfg(feature = "sync")]
-pub fn read_chunk<R: Read>(reader: &mut R) -> Result<Vec<u8>> {
+pub fn read_chunk<R: Read>(reader: &mut R) -> Result<Vec<u8>, std::io::Error> {
     let mut chunk = Vec::with_capacity(CHUNK_SIZE);
     let mut take = reader.take(CHUNK_SIZE as u64);
     take.read_to_end(&mut chunk)?;


### PR DESCRIPTION
This is a repost of #166 (rebased on top of master), because I don't know why you closed the previous PR, and thus if this feature is wanted or not ?

Following discussion at #164, this PR replaces anyhow with thiserror to make errors more explicit, comparable, and so on. The goal is for consumers of this library to be able to extract information about errors without having to downcast anyhow errors, and thus to have more granularity to filter the errors and/or understand the issue at hand.

As an important note, this is not API compatible with the current 0.27 branch and probably harder to accept that when rust-s3 0.27 was still in beta.