### PR TITLE
add custom headers on put_object requests

### DIFF
--- a/s3/src/command.rs
+++ b/s3/src/command.rs
@@ -68,6 +68,7 @@ pub enum Command<'a> {
         content: &'a [u8],
         content_type: &'a str,
         multipart: Option<Multipart<'a>>,
+        custom_headers: Option<HeaderMap>,
     },
     PutObjectTagging {
         tags: &'a str,
@@ -96,7 +97,9 @@ pub enum Command<'a> {
     PresignDelete {
         expiry_secs: u32,
     },
-    InitiateMultipartUpload,
+    InitiateMultipartUpload {
+        custom_headers: Option<HeaderMap>,
+    },
     UploadPart {
         part_number: u32,
         content: &'a [u8],
@@ -137,7 +140,7 @@ impl<'a> Command<'a> {
             | Command::AbortMultipartUpload { .. }
             | Command::PresignDelete { .. }
             | Command::DeleteBucket => HttpMethod::Delete,
-            Command::InitiateMultipartUpload | Command::CompleteMultipartUpload { .. } => {
+            Command::InitiateMultipartUpload { .. } | Command::CompleteMultipartUpload { .. } => {
                 HttpMethod::Post
             }
             Command::HeadObject => HttpMethod::Head,


### PR DESCRIPTION
This is a repost of #155 (rebased on top of master), because I don't know why you closed the previous PR, and thus if this feature is wanted or not ?

I'm quite lazy, so I didn't want to upload objects with a presigned put (which allows for passing custom metadata). This means I had to be able to pass custom headers (in theory I only needed to add "x-amz-meta-*", but while we are at it, wa can as well let the user add any possible header, right ?). This is an attempt at solving this problem.
However, I do think that this PR is less than ideal because

* a builder pattern would probably prevent adding too many similar functions, and be better than this hacky patch
* we forward custom_headers to the s3 endpoint both for submitting parts & for initiating the upload, without distinguishing both (in the event of a multi-parts upload of course, otherwise there is no such dichotomy because there is only a single request). However adding two arguments would be tedious and there is no way to distinguish the headers targeting the parts from those targeting the InitiateMultipartUpload query. So I decided to send the same headers for both.

Anyway, do you think something like that would be valuable ?