### PR TITLE
Implement presign_delete

### DIFF
--- a/s3/src/bucket.rs
+++ b/s3/src/bucket.rs
@@ -168,6 +168,29 @@ impl Bucket {
         );
         request.presigned()
     }
+
+    /// Get a presigned url for deleting object on a given path
+    ///
+    /// # Example:
+    ///
+    /// ```no_run
+    /// use s3::bucket::Bucket;
+    /// use s3::creds::Credentials;
+    ///
+    /// let bucket_name = "rust-s3-test";
+    /// let region = "us-east-1".parse().unwrap();
+    /// let credentials = Credentials::default().unwrap();
+    /// let bucket = Bucket::new(bucket_name, region, credentials).unwrap();
+    ///
+    /// let url = bucket.presign_delete("/test.file", 86400).unwrap();
+    /// println!("Presigned url: {}", url);
+    /// ```
+    pub fn presign_delete<S: AsRef<str>>(&self, path: S, expiry_secs: u32) -> Result<String> {
+        validate_expiry(expiry_secs)?;
+        let request = RequestImpl::new(self, path.as_ref(), Command::PresignDelete { expiry_secs });
+        request.presigned()
+    }
+
     /// Create a new `Bucket` and instantiate it
     ///
     /// ```no_run
@@ -2072,6 +2095,16 @@ mod test {
         let bucket = test_aws_bucket();
 
         let url = bucket.presign_get(s3_path, 86400).unwrap();
+        assert!(url.contains("/test%2Ftest.file?"))
+    }
+
+    #[test]
+    #[ignore]
+    fn test_presign_delete() {
+        let s3_path = "/test/test.file";
+        let bucket = test_aws_bucket();
+
+        let url = bucket.presign_delete(s3_path, 86400).unwrap();
         assert!(url.contains("/test%2Ftest.file?"))
     }
 

--- a/s3/src/command.rs
+++ b/s3/src/command.rs
@@ -90,6 +90,9 @@ pub enum Command<'a> {
         expiry_secs: u32,
         custom_headers: Option<HeaderMap>,
     },
+    PresignDelete {
+        expiry_secs: u32,
+    },
     InitiateMultipartUpload,
     UploadPart {
         part_number: u32,
@@ -128,6 +131,7 @@ impl<'a> Command<'a> {
             Command::DeleteObject
             | Command::DeleteObjectTagging
             | Command::AbortMultipartUpload { .. }
+            | Command::PresignDelete { .. }
             | Command::DeleteBucket => HttpMethod::Delete,
             Command::InitiateMultipartUpload | Command::CompleteMultipartUpload { .. } => {
                 HttpMethod::Post

--- a/s3/src/request_trait.rs
+++ b/s3/src/request_trait.rs
@@ -80,6 +80,7 @@ pub trait Request {
         let expiry = match self.command() {
             Command::PresignGet { expiry_secs } => expiry_secs,
             Command::PresignPut { expiry_secs, .. } => expiry_secs,
+            Command::PresignDelete { expiry_secs } => expiry_secs,
             _ => unreachable!(),
         };
 
@@ -125,6 +126,7 @@ pub trait Request {
         let expiry = match self.command() {
             Command::PresignGet { expiry_secs } => expiry_secs,
             Command::PresignPut { expiry_secs, .. } => expiry_secs,
+            Command::PresignDelete { expiry_secs } => expiry_secs,
             _ => unreachable!(),
         };
 


### PR DESCRIPTION
This PR implements `presign_delete`, mirroring `presign_get` exactly. I'm not exactly certain that the S3 spec intends for a presigned DELETE but rusoto seems to implement it 🤷‍♂️ .
This is tested against Exoscale and B2. For Exoscale it works as expected, B2 interestingly returns a CORS error if a DELETE is attempted on the URL after the expiration.

Note, this is was a quick fix and I didn't have a deep look at this code, so proceed accordingly.