### PR TITLE
Implement CopyObject bucket operation

### DIFF
--- a/s3/src/bucket.rs
+++ b/s3/src/bucket.rs
@@ -411,6 +411,51 @@ impl Bucket {
         })
     }
 
+    /// Copy file from an S3 path, internally within the same bucket.
+    ///
+    /// # Example:
+    ///
+    /// ```rust,no_run
+    /// use s3::bucket::Bucket;
+    /// use s3::creds::Credentials;
+    /// use anyhow::Result;
+    ///
+    /// # #[tokio::main]
+    /// # async fn main() -> Result<()> {
+    ///
+    /// let bucket_name = "rust-s3-test";
+    /// let region = "us-east-1".parse()?;
+    /// let credentials = Credentials::default()?;
+    /// let bucket = Bucket::new(bucket_name, region, credentials)?;
+    ///
+    /// // Async variant with `tokio` or `async-std` features
+    /// let code = bucket.copy_object_internal("/from.file", "/to.file").await?;
+    ///
+    /// // `sync` feature will produce an identical method
+    /// #[cfg(feature = "sync")]
+    /// let code = bucket.copy_object_internal("/from.file", "/to.file")?;
+    ///
+    /// # Ok(())
+    /// # }
+    /// ```
+    #[maybe_async::maybe_async]
+    pub async fn copy_object_internal<F: AsRef<str>, T: AsRef<str>>(&self, from: F, to: T) -> Result<u16> {
+        let fq_from = {
+            let from = from.as_ref();
+            let from = from.strip_prefix("/").unwrap_or(from);
+            format!("{bucket}/{path}", bucket=self.name(), path=from)
+        };
+        self.copy_object(fq_from, to).await
+    }
+
+    #[maybe_async::maybe_async]
+    async fn copy_object<F: AsRef<str>, T: AsRef<str>>(&self, from: F, to: T) -> Result<u16> {
+        let command = Command::CopyObject { from: from.as_ref() };
+        let request = RequestImpl::new(self, to.as_ref(), command);
+        let (_, code) = request.response_data(false).await?;
+        Ok(code)
+    }
+
     /// Gets file from an S3 path.
     ///
     /// # Example:

--- a/s3/src/command.rs
+++ b/s3/src/command.rs
@@ -52,6 +52,9 @@ impl<'a> Multipart<'a> {
 #[derive(Clone, Debug)]
 pub enum Command<'a> {
     HeadObject,
+    CopyObject {
+        from: &'a str,
+    },
     DeleteObject,
     DeleteObjectTagging,
     GetObject,
@@ -112,6 +115,7 @@ pub enum Command<'a> {
 impl<'a> Command<'a> {
     pub fn http_verb(&self) -> HttpMethod {
         match *self {
+            Command::CopyObject { from: _ } => HttpMethod::Put,
             Command::GetObject
             | Command::GetObjectTorrent
             | Command::GetObjectRange { .. }
@@ -138,6 +142,7 @@ impl<'a> Command<'a> {
 
     pub fn content_length(&self) -> usize {
         match &self {
+            Command::CopyObject { from: _ } => 0,
             Command::PutObject { content, .. } => content.len(),
             Command::PutObjectTagging { tags } => tags.len(),
             Command::UploadPart { content, .. } => content.len(),

--- a/s3/src/request_trait.rs
+++ b/s3/src/request_trait.rs
@@ -318,6 +318,10 @@ pub trait Request {
         headers.insert(HOST, host_header.parse().unwrap());
 
         match self.command() {
+            Command::CopyObject { from } => {
+                headers.insert(HeaderName::from_static("x-amz-copy-source"),
+                from.parse().unwrap());
+            }
             Command::ListBucket { .. } => {}
             Command::GetObject => {}
             Command::GetObjectTagging => {}


### PR DESCRIPTION
Copy across different buckets is not exposed, purposefully, in order to not make the API too complex on the first impl.