### PR TITLE
bucket: add optional HTTP timeout for all bucket operations

### DIFF
--- a/s3/src/blocking.rs
+++ b/s3/src/blocking.rs
@@ -67,6 +67,10 @@ impl<'a> Request for AttoRequest<'a> {
             session.header(HeaderName::from_bytes(name.as_ref()).unwrap(), value);
         }
 
+        if let Some(timeout) = self.bucket.request_timeout {
+            session.timeout(timeout)
+        }
+
         let request = match self.command.http_verb() {
             HttpMethod::Get => session.get(self.url()),
             HttpMethod::Delete => session.delete(self.url()),

--- a/s3/src/bucket.rs
+++ b/s3/src/bucket.rs
@@ -4,6 +4,7 @@ use minidom::Element;
 use serde_xml_rs as serde_xml;
 use std::collections::HashMap;
 use std::mem;
+use std::time::Duration;
 
 use crate::bucket_ops::{BucketConfiguration, CreateBucketResponse};
 use crate::command::{Command, Multipart};
@@ -85,6 +86,7 @@ pub struct Bucket {
     pub credentials: Credentials,
     pub extra_headers: HeaderMap,
     pub extra_query: Query,
+    pub request_timeout: Option<Duration>,
     path_style: bool,
 }
 
@@ -333,6 +335,7 @@ impl Bucket {
             credentials,
             extra_headers: HeaderMap::new(),
             extra_query: HashMap::new(),
+            request_timeout: None,
             path_style: false,
         })
     }
@@ -356,6 +359,7 @@ impl Bucket {
             credentials: Credentials::anonymous()?,
             extra_headers: HeaderMap::new(),
             extra_query: HashMap::new(),
+            request_timeout: None,
             path_style: false,
         })
     }
@@ -384,6 +388,7 @@ impl Bucket {
             credentials,
             extra_headers: HeaderMap::new(),
             extra_query: HashMap::new(),
+            request_timeout: None,
             path_style: true,
         })
     }
@@ -407,6 +412,7 @@ impl Bucket {
             credentials: Credentials::anonymous()?,
             extra_headers: HeaderMap::new(),
             extra_query: HashMap::new(),
+            request_timeout: None,
             path_style: true,
         })
     }
@@ -1421,7 +1427,7 @@ impl Bucket {
         self.path_style
     }
 
-    // Get negated path_style field of the Bucket struct
+    /// Get negated path_style field of the Bucket struct
     pub fn is_subdomain_style(&self) -> bool {
         !self.path_style
     }
@@ -1434,6 +1440,15 @@ impl Bucket {
     /// Configure bucket to use subdomain style urls and headers \[default\]
     pub fn set_subdomain_style(&mut self) {
         self.path_style = false;
+    }
+
+    /// Configure bucket to apply this request timeout to all HTTP
+    /// requests, or no (infinity) timeout if `None`.
+    ///
+    /// Only the attohttpc and the Reqwest backends obey this option;
+    /// async code may instead await with a timeout.
+    pub fn set_request_timeout(&mut self, timeout: Option<Duration>) {
+        self.request_timeout = timeout;
     }
 
     /// Get a reference to the name of the S3 bucket.


### PR DESCRIPTION
And apply the new field in the attohttpc (blocking) and reqwest
backends.  Surf does not expose such an option, but it's also
not as useful in async code: the caller can await with timeout.