### PR TITLE
s3/bucket: default to 30-second request timeout

### DIFF
--- a/s3/src/bucket.rs
+++ b/s3/src/bucket.rs
@@ -49,6 +49,8 @@ use http::HeaderMap;
 
 pub const CHUNK_SIZE: usize = 8_388_608; // 8 Mebibytes, min is 5 (5_242_880);
 
+const DEFAULT_REQUEST_TIMEOUT: Option<Duration> = Some(Duration::from_secs(30));
+
 #[derive(Debug, PartialEq)]
 pub struct Tag {
     key: String,
@@ -358,7 +360,7 @@ impl Bucket {
             credentials,
             extra_headers: HeaderMap::new(),
             extra_query: HashMap::new(),
-            request_timeout: None,
+            request_timeout: DEFAULT_REQUEST_TIMEOUT,
             path_style: false,
         })
     }
@@ -382,7 +384,7 @@ impl Bucket {
             credentials: Credentials::anonymous()?,
             extra_headers: HeaderMap::new(),
             extra_query: HashMap::new(),
-            request_timeout: None,
+            request_timeout: DEFAULT_REQUEST_TIMEOUT,
             path_style: false,
         })
     }
@@ -411,7 +413,7 @@ impl Bucket {
             credentials,
             extra_headers: HeaderMap::new(),
             extra_query: HashMap::new(),
-            request_timeout: None,
+            request_timeout: DEFAULT_REQUEST_TIMEOUT,
             path_style: true,
         })
     }
@@ -435,7 +437,7 @@ impl Bucket {
             credentials: Credentials::anonymous()?,
             extra_headers: HeaderMap::new(),
             extra_query: HashMap::new(),
-            request_timeout: None,
+            request_timeout: DEFAULT_REQUEST_TIMEOUT,
             path_style: true,
         })
     }
@@ -1515,7 +1517,8 @@ impl Bucket {
     }
 
     /// Configure bucket to apply this request timeout to all HTTP
-    /// requests, or no (infinity) timeout if `None`.
+    /// requests, or no (infinity) timeout if `None`.  Defaults to
+    /// 30 seconds.
     ///
     /// Only the attohttpc and the Reqwest backends obey this option;
     /// async code may instead await with a timeout.


### PR DESCRIPTION
No (infinite) timeout is a bad default. It's easy for libraries to override their bucket objects' timeout, but we should probably default to *some* timeout, rather than letting requests remain stuck forever (up to TCP timeout).

I'm not 100% convinced this change is a good idea: large uploads or downloads can last a more than 30 seconds... On the other hand, it's easier to observe a timeout and relax the maximum duration, compared to realising that a program is stuck because there's no timeout on S3 calls. What do you think?