### PR TITLE
aws-creds: simplify and deduplicate `is_ec2` check

### DIFF
--- a/aws-creds/src/credentials.rs
+++ b/aws-creds/src/credentials.rs
@@ -278,13 +278,7 @@ impl Credentials {
                     .json()?
             }
             Err(_) => {
-                if !(std::fs::read_to_string("/sys/hypervisor/uuid")
-                    .map_or(false, |uuid| uuid.len() >= 3 && &uuid[..3] == "ec2")
-                    || std::fs::read_to_string("/sys/class/dmi/id/board_vendor")
-                        .map_or(false, |uuid| {
-                            uuid.len() >= 10 && &uuid[..10] == "Amazon EC2"
-                        }))
-                {
+                if !Credentials::is_ec2() {
                     bail!("Not an AWS instance")
                 }
                 // We are on EC2
@@ -314,12 +308,12 @@ impl Credentials {
 
     fn is_ec2() -> bool {
         if let Ok(uuid) = std::fs::read_to_string("/sys/hypervisor/uuid") {
-            if uuid.len() >= 3 && &uuid[..3] == "ec2" {
+            if uuid.starts_with("ec2") {
                 return true;
             }
         }
-        if let Ok(uuid) = std::fs::read_to_string("/sys/class/dmi/id/board_vendor") {
-            if uuid.len() >= 10 && &uuid[..10] == "Amazon EC2" {
+        if let Ok(vendor) = std::fs::read_to_string("/sys/class/dmi/id/board_vendor") {
+            if vendor.starts_with("Amazon EC2") {
                 return true;
             }
         }


### PR DESCRIPTION
1. Call `is_ec2` in `Credentials::from_instance_metadata` instead of
   duplicating a slightly different logic.

2. Use `str::starts_with` when that's what we mean.

The only observable difference is that `::from_instance_metadata` will
now accept a machine as being on ec2 if either `/sys/hypervisor/uuid`
or `/sys/class/dmi/id/board_vendor` match, while the previous version
only did when *both* files matched.  That seems reasonable enough.