### PR TITLE
Fix slash being encoded where it shouldn't be

### DIFF
--- a/s3/Cargo.toml
+++ b/s3/Cargo.toml
@@ -61,7 +61,6 @@ tokio-rustls-tls = ["with-tokio", "reqwest/rustls-tls", "aws-creds/rustls-tls"]
 sync-native-tls = ["sync", "aws-creds/native-tls", "attohttpc/tls"]
 sync-rustls-tls = ["sync", "aws-creds/rustls-tls", "attohttpc/tls-rustls"]
 blocking = ["block_on_proc", "tokio/rt", "tokio/rt-multi-thread"]
-never-encode-slash = []
 
 [dev-dependencies]
 tokio = { version = "1", features = ["rt", "rt-multi-thread", "macros"] }

--- a/s3/src/request_trait.rs
+++ b/s3/src/request_trait.rs
@@ -188,7 +188,10 @@ pub trait Request {
 
         url_str.push('/');
 
+        #[cfg(not(feature = "never-encode-slash"))]
         url_str.push_str(&signing::uri_encode(&path, true));
+        #[cfg(feature = "never-encode-slash")]
+        url_str.push_str(&signing::uri_encode(&path, false));
 
         // Append to url_path
         #[allow(clippy::collapsible_match)]

--- a/s3/src/request_trait.rs
+++ b/s3/src/request_trait.rs
@@ -187,10 +187,6 @@ pub trait Request {
         };
 
         url_str.push('/');
-
-        #[cfg(not(feature = "never-encode-slash"))]
-        url_str.push_str(&signing::uri_encode(&path, true));
-        #[cfg(feature = "never-encode-slash")]
         url_str.push_str(&signing::uri_encode(&path, false));
 
         // Append to url_path

--- a/s3/src/signing.rs
+++ b/s3/src/signing.rs
@@ -56,18 +56,12 @@ pub const FRAGMENT: &AsciiSet = &CONTROLS
 pub const FRAGMENT_SLASH: &AsciiSet = &FRAGMENT.add(b'/');
 
 /// Encode a URI following the specific requirements of the AWS service.
-#[cfg(not(feature = "never-encode-slash"))]
 pub fn uri_encode(string: &str, encode_slash: bool) -> String {
     if encode_slash {
         utf8_percent_encode(string, FRAGMENT_SLASH).to_string()
     } else {
         utf8_percent_encode(string, FRAGMENT).to_string()
     }
-}
-
-#[cfg(feature = "never-encode-slash")]
-pub fn uri_encode(string: &str, encode_slash: bool) -> String {
-    utf8_percent_encode(string, FRAGMENT).to_string()
 }
 
 /// Generate a canonical URI string from the given URL.


### PR DESCRIPTION
Unless this breaks the usage of this library with other S3 implementations, I think this is the right way to go.

This only changes `uri_encode` in a single place (`Request::url`) rather than the current `never-encode-slash` feature which makes the `encode_slash` parameter on `uri_encode` meaningless if activated, and doesn't work for DO spaces the same way the default feature set doesn't work for it.

If you want to be conservative, you can only cherry-pick the first commit, then the behavior change only applies when `never-encode-slash` is activated (though the feature name is wrong, then).

Properly fixes #144.