### PR TITLE
Make minidom dependency optional

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,7 @@ There are a lot of various featuers that enable a wide variaty of use cases, ref
 
 + `with-async-std` - `async-std` runtime
 + `sync` - no async runtime, `attohttpc` is used for HTTP requests
++ `tags` - required for `Bucket::get_object_tagging`
 
 All runtimes support either `native-tls` or `rustls-tls`, there are features for all combinations, refer to `s3/Cargo.toml` for a complete list
 

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ There are a lot of various featuers that enable a wide variaty of use cases, ref
 ##### with `default-features = false`
 
 + `with-async-std` - `async-std` runtime
-+ `sync` - no async rutime, `attohttpc` is used for HTTP requests
++ `sync` - no async runtime, `attohttpc` is used for HTTP requests
 
 All runtimes support either `native-tls` or `rustls-tls`, there are features for all combinations, refer to `s3/Cargo.toml` for a complete list
 

--- a/s3/Cargo.toml
+++ b/s3/Cargo.toml
@@ -45,7 +45,7 @@ surf = { version = "2", optional = true, default-features = false, features = ["
 tokio = { version = "1", features = ["io-util"], optional = true, default-features = false }
 tokio-stream = "0.1"
 url = "2"
-minidom = "0.13"
+minidom = { version = "0.13", optional = true }
 
 block_on_proc = { version = "0.2", optional = true }
 
@@ -53,7 +53,7 @@ block_on_proc = { version = "0.2", optional = true }
 with-tokio = ["reqwest", "tokio", "futures", "tokio/fs"]
 with-async-std = ["async-std", "surf", "futures"]
 sync = ["attohttpc", "maybe-async/is_sync"]
-default = ["tokio-native-tls"]
+default = ["tags", "tokio-native-tls"]
 no-verify-ssl = []
 fail-on-err = []
 tokio-native-tls = ["with-tokio", "reqwest/native-tls", "aws-creds/native-tls"]
@@ -62,6 +62,7 @@ sync-native-tls = ["sync", "aws-creds/native-tls", "attohttpc/tls"]
 sync-rustls-tls = ["sync", "aws-creds/rustls-tls", "attohttpc/tls-rustls"]
 blocking = ["block_on_proc", "tokio/rt", "tokio/rt-multi-thread"]
 never-encode-slash = []
+tags = ["minidom"]
 
 [dev-dependencies]
 tokio = { version = "1", features = ["rt", "rt-multi-thread", "macros"] }

--- a/s3/src/bucket.rs
+++ b/s3/src/bucket.rs
@@ -1,5 +1,6 @@
 #[cfg(feature = "blocking")]
 use block_on_proc::block_on;
+#[cfg(feature = "tags")]
 use minidom::Element;
 use serde_xml_rs as serde_xml;
 use std::collections::HashMap;
@@ -1231,6 +1232,7 @@ impl Bucket {
     /// # Ok(())
     /// # }
     /// ```
+    #[cfg(feature = "tags")]
     #[maybe_async::maybe_async]
     pub async fn get_object_tagging<S: AsRef<str>>(&self, path: S) -> Result<(Vec<Tag>, u16)> {
         let command = Command::GetObjectTagging {};
@@ -1806,6 +1808,7 @@ mod test {
     }
 
     #[ignore]
+    #[cfg(feature = "tags")]
     #[maybe_async::test(
         feature = "sync",
         async(all(not(feature = "sync"), feature = "with-tokio"), tokio::test),


### PR DESCRIPTION
This one function pulls in both minidom and quick-xml, and we have never used it. Would be nice to be able to get rid of those extra dependencies.