### PR TITLE
Add support for the older ListObjects API

### DIFF
--- a/s3/src/bucket.rs
+++ b/s3/src/bucket.rs
@@ -88,6 +88,7 @@ pub struct Bucket {
     pub extra_query: Query,
     pub request_timeout: Option<Duration>,
     path_style: bool,
+    listobjects_v2: bool,
 }
 
 fn validate_expiry(expiry_secs: u32) -> Result<()> {
@@ -360,6 +361,7 @@ impl Bucket {
             extra_query: HashMap::new(),
             request_timeout: None,
             path_style: false,
+            listobjects_v2: true,
         })
     }
 
@@ -384,6 +386,7 @@ impl Bucket {
             extra_query: HashMap::new(),
             request_timeout: None,
             path_style: false,
+            listobjects_v2: true,
         })
     }
 
@@ -413,6 +416,7 @@ impl Bucket {
             extra_query: HashMap::new(),
             request_timeout: None,
             path_style: true,
+            listobjects_v2: true,
         })
     }
 
@@ -437,6 +441,7 @@ impl Bucket {
             extra_query: HashMap::new(),
             request_timeout: None,
             path_style: true,
+            listobjects_v2: true,
         })
     }
 
@@ -1277,13 +1282,27 @@ impl Bucket {
         start_after: Option<String>,
         max_keys: Option<usize>,
     ) -> Result<(ListBucketResult, u16)> {
-        let command = Command::ListBucket {
-            prefix,
-            delimiter,
-            continuation_token,
-            start_after,
-            max_keys,
-        };
+
+        let command =
+            if self.listobjects_v2 {
+                Command::ListObjectsV2 {
+                    prefix,
+                    delimiter,
+                    continuation_token,
+                    start_after,
+                    max_keys,
+                }
+            } else {
+                // In the v1 ListObjects request, there is only one "marker"
+                // field that serves as both the initial starting position,
+                // and as the continuation token.
+                Command::ListObjects {
+                    prefix,
+                    delimiter,
+                    marker: std::cmp::max(continuation_token, start_after),
+                    max_keys,
+                }
+            };
         let request = RequestImpl::new(self, "/", command);
         let (response, status_code) = request.response_data(false).await?;
         return serde_xml::from_reader(response.as_slice())
@@ -1523,6 +1542,20 @@ impl Bucket {
         self.request_timeout = timeout;
     }
 
+    /// Configure bucket to use the older ListObjects API
+    ///
+    /// If your provider doesn't support the ListObjectsV2 interface, set this to
+    /// use the v1 ListObjects interface instead. This is currently needed at least
+    /// for Google Cloud Storage.
+    pub fn set_listobjects_v1(&mut self) {
+        self.listobjects_v2 = false;
+    }
+
+    /// Configure bucket to use the newer ListObjectsV2 API
+    pub fn set_listobjects_v2(&mut self) {
+        self.listobjects_v2 = true;
+    }
+
     /// Get a reference to the name of the S3 bucket.
     pub fn name(&self) -> String {
         self.name.to_string()
@@ -1742,7 +1775,7 @@ mod test {
     }
 
     fn test_gc_bucket() -> Bucket {
-        Bucket::new(
+        let mut bucket =  Bucket::new(
             "rust-s3",
             Region::Custom {
                 region: "us-east1".to_owned(),
@@ -1750,7 +1783,9 @@ mod test {
             },
             test_gc_credentials(),
         )
-        .unwrap()
+        .unwrap();
+        bucket.set_listobjects_v1();
+        return bucket;
     }
 
     fn test_minio_bucket() -> Bucket {
@@ -1959,18 +1994,22 @@ mod test {
     }
 
     #[cfg(feature = "blocking")]
-    fn put_head_get_delete_object_blocking(bucket: Bucket) {
+    fn put_head_get_list_delete_object_blocking(bucket: Bucket) {
         let s3_path = "/test_blocking.file";
         let test: Vec<u8> = object(3072);
 
+        // Test PutObject
         let (_data, code) = bucket.put_object_blocking(s3_path, &test).unwrap();
         // println!("{}", std::str::from_utf8(&data).unwrap());
         assert_eq!(code, 200);
+
+        // Test GetObject
         let (data, code) = bucket.get_object_blocking(s3_path).unwrap();
         assert_eq!(code, 200);
         // println!("{}", std::str::from_utf8(&data).unwrap());
         assert_eq!(test, data);
 
+        // Test GetObject with a range
         let (data, code) = bucket
             .get_object_range_blocking(s3_path, 100, Some(1000))
             .unwrap();
@@ -1978,6 +2017,7 @@ mod test {
         // println!("{}", std::str::from_utf8(&data).unwrap());
         assert_eq!(test[100..1001].to_vec(), data);
 
+        // Test HeadObject
         let (head_object_result, code) = bucket.head_object_blocking(s3_path).unwrap();
         assert_eq!(code, 200);
         assert_eq!(
@@ -1985,7 +2025,42 @@ mod test {
             "application/octet-stream".to_owned()
         );
         // println!("{:?}", head_object_result);
+
+        // Put some additional objects, so that we can test ListObjects
+        let (_data, code) = bucket.put_object(s3_path2, &test).await.unwrap();
+        assert_eq!(code, 200);
+        let (_data, code) = bucket.put_object(s3_path3, &test).await.unwrap();
+        assert_eq!(code, 200);
+
+        // Test ListObjects, with continuation
+        let (result, code) = bucket.list_page("test.".to_string(),
+                                              Some("/".to_string()),
+                                              None,
+                                              None,
+                                              Some(2)).await.unwrap();
+        assert_eq!(code, 200);
+        assert_eq!(result.contents.len(), 2);
+        assert_eq!(result.contents[0].key, "test.file");
+        assert_eq!(result.contents[1].key, "test.file2");
+
+        let cont_token = result.next_continuation_token.unwrap();
+
+        let (result, code) = bucket.list_page("test.".to_string(),
+                                              Some("/".to_string()),
+                                              Some(cont_token),
+                                              None,
+                                              Some(2)).await.unwrap();
+        assert_eq!(code, 200);
+        assert_eq!(result.contents.len(), 1);
+        assert_eq!(result.contents[0].key, "test.file3");
+        assert!(result.next_continuation_token.is_none());
+
+        // cleanup (and test Delete)
         let (_, code) = bucket.delete_object_blocking(s3_path).unwrap();
+        assert_eq!(code, 204);
+        let (_, code) = bucket.delete_object(s3_path2).await.unwrap();
+        assert_eq!(code, 204);
+        let (_, code) = bucket.delete_object(s3_path3).await.unwrap();
         assert_eq!(code, 204);
     }
 

--- a/s3/src/command.rs
+++ b/s3/src/command.rs
@@ -78,7 +78,13 @@ pub enum Command<'a> {
         key_marker: Option<String>,
         max_uploads: Option<usize>,
     },
-    ListBucket {
+    ListObjects {
+        prefix: String,
+        delimiter: Option<String>,
+        marker: Option<String>,
+        max_keys: Option<usize>,
+    },
+    ListObjectsV2 {
         prefix: String,
         delimiter: Option<String>,
         continuation_token: Option<String>,
@@ -122,7 +128,8 @@ impl<'a> Command<'a> {
             Command::GetObject
             | Command::GetObjectTorrent
             | Command::GetObjectRange { .. }
-            | Command::ListBucket { .. }
+            | Command::ListObjects { .. }
+            | Command::ListObjectsV2 { .. }
             | Command::GetBucketLocation
             | Command::GetObjectTagging
             | Command::ListMultipartUploads { .. }

--- a/s3/src/request_trait.rs
+++ b/s3/src/request_trait.rs
@@ -221,7 +221,7 @@ pub trait Request {
 
         // println!("{}", url_str);
 
-        if let Command::ListBucket {
+        if let Command::ListObjectsV2 {
             prefix,
             delimiter,
             continuation_token,
@@ -231,6 +231,7 @@ pub trait Request {
         {
             let mut query_pairs = url.query_pairs_mut();
             delimiter.map(|d| query_pairs.append_pair("delimiter", &d));
+
             query_pairs.append_pair("prefix", &prefix);
             query_pairs.append_pair("list-type", "2");
             if let Some(token) = continuation_token {
@@ -238,6 +239,25 @@ pub trait Request {
             }
             if let Some(start_after) = start_after {
                 query_pairs.append_pair("start-after", &start_after);
+            }
+            if let Some(max_keys) = max_keys {
+                query_pairs.append_pair("max-keys", &max_keys.to_string());
+            }
+        }
+
+        if let Command::ListObjects {
+            prefix,
+            delimiter,
+            marker,
+            max_keys,
+        } = self.command().clone()
+        {
+            let mut query_pairs = url.query_pairs_mut();
+            delimiter.map(|d| query_pairs.append_pair("delimiter", &d));
+
+            query_pairs.append_pair("prefix", &prefix);
+            if let Some(marker) = marker {
+                query_pairs.append_pair("marker", &marker);
             }
             if let Some(max_keys) = max_keys {
                 query_pairs.append_pair("max-keys", &max_keys.to_string());
@@ -324,7 +344,8 @@ pub trait Request {
                     from.parse().unwrap(),
                 );
             }
-            Command::ListBucket { .. } => {}
+            Command::ListObjects { .. } => {}
+            Command::ListObjectsV2 { .. } => {}
             Command::GetObject => {}
             Command::GetObjectTagging => {}
             Command::GetBucketLocation => {}

--- a/s3/src/serde_types.rs
+++ b/s3/src/serde_types.rs
@@ -31,7 +31,7 @@ pub struct Object {
     pub e_tag: String,
     #[serde(rename = "StorageClass")]
     /// STANDARD | STANDARD_IA | REDUCED_REDUNDANCY | GLACIER
-    pub storage_class: String,
+    pub storage_class: Option<String>,
     #[serde(rename = "Key")]
     /// The object's key
     pub key: String,
@@ -109,30 +109,27 @@ pub struct BucketLocationResult {
 }
 
 /// The parsed result of a s3 bucket listing
+///
+/// This accepts the ListBucketResult format returned for both ListObjects and ListObjectsV2
 #[derive(Deserialize, Debug, Clone)]
 pub struct ListBucketResult {
     #[serde(rename = "Name")]
     /// Name of the bucket.
     pub name: String,
-    #[serde(rename = "NextMarker")]
-    /// When the response is truncated (that is, the IsTruncated element value in the response
-    /// is true), you can use the key name in this field as a marker in the subsequent request
-    /// to get next set of objects. Amazon S3 lists objects in UTF-8 character encoding in
-    /// lexicographical order.
-    pub next_marker: Option<String>,
     #[serde(rename = "Delimiter")]
     /// A delimiter is a character you use to group keys.
     pub delimiter: Option<String>,
     #[serde(rename = "MaxKeys")]
     /// Sets the maximum number of keys returned in the response body.
-    pub max_keys: i32,
+    pub max_keys: Option<i32>,
     #[serde(rename = "Prefix")]
     /// Limits the response to keys that begin with the specified prefix.
     pub prefix: String,
-    #[serde(rename = "Marker")]
-    /// Indicates where in the bucket listing begins. Marker is included in the response if
+    #[serde(rename = "ContinuationToken")]  // for ListObjectsV2 request
+    #[serde(alias = "Marker")]  // for ListObjects request
+    /// Indicates where in the bucket listing begins. It is included in the response if
     /// it was sent with the request.
-    pub marker: Option<String>,
+    pub continuation_token: Option<String>,
     #[serde(rename = "EncodingType")]
     /// Specifies the encoding method to used
     pub encoding_type: Option<String>,
@@ -143,8 +140,14 @@ pub struct ListBucketResult {
     ///  Specifies whether (true) or not (false) all of the results were returned.
     ///  If the number of results exceeds that specified by MaxKeys, all of the results
     ///  might not be returned.
+
+    /// When the response is truncated (that is, the IsTruncated element value in the response
+    /// is true), you can use the key name in in 'next_continuation_token' as a marker in the
+    /// subsequent request to get next set of objects. Amazon S3 lists objects in UTF-8 character
+    /// encoding in lexicographical order.
     pub is_truncated: bool,
-    #[serde(rename = "NextContinuationToken", default)]
+    #[serde(rename = "NextContinuationToken", default)]  // for ListObjectsV2 request
+    #[serde(alias = "NextMarker")]  // for ListObjects request
     pub next_continuation_token: Option<String>,
     #[serde(rename = "Contents", default)]
     /// Metadata about each object returned.


### PR DESCRIPTION
Google Cloud Storage doesn't support the newer ListObjectsV2 call.

This is a rebase of https://github.com/durch/rust-s3/pull/175. (That PR was closed with no explanation, I'm not sure what happened there..)