### PR TITLE
Use async write for tokio,async-std

### DIFF
--- a/s3/src/surf_request.rs
+++ b/s3/src/surf_request.rs
@@ -1,5 +1,5 @@
-use async_std::io::ReadExt;
-use std::io::Write;
+use async_std::io::{ReadExt, WriteExt};
+use futures::io::AsyncWrite;
 
 use super::bucket::Bucket;
 use super::command::Command;
@@ -88,7 +88,7 @@ impl<'a> Request for SurfRequest<'a> {
         Ok((body_vec, status_code.into()))
     }
 
-    async fn response_data_to_writer<T: Write + Send>(&self, writer: &mut T) -> Result<u16> {
+    async fn response_data_to_writer<T: AsyncWrite + Send + Unpin>(&self, writer: &mut T) -> Result<u16> {
         let mut buffer = Vec::new();
 
         let response = self.response().await?;
@@ -99,7 +99,7 @@ impl<'a> Request for SurfRequest<'a> {
 
         stream.read_to_end(&mut buffer).await?;
 
-        writer.write_all(&buffer)?;
+        writer.write_all(&buffer).await?;
 
         Ok(status_code.into())
     }

--- a/s3/src/utils.rs
+++ b/s3/src/utils.rs
@@ -33,7 +33,7 @@ use tokio::io::{AsyncRead, AsyncReadExt};
 ///     println!("{}", etag);
 /// }
 /// ```
-#[cfg(any(feature = "tokio", feature = "async-std"))]
+#[cfg(any(feature = "with-tokio", feature = "with-async-std"))]
 pub async fn etag_for_path(path: impl AsRef<Path>) -> Result<String> {
     let mut file = File::open(path).await?;
     let mut digests = Vec::new();
@@ -87,7 +87,7 @@ pub fn etag_for_path(path: impl AsRef<Path>) -> Result<String> {
     Ok(etag)
 }
 
-#[cfg(any(feature = "tokio", feature = "async-std"))]
+#[cfg(any(feature = "with-tokio", feature = "with-async-std"))]
 pub async fn read_chunk<R: AsyncRead + Unpin>(reader: &mut R) -> Result<Vec<u8>> {
     let mut chunk = Vec::with_capacity(CHUNK_SIZE);
     let mut take = reader.take(CHUNK_SIZE as u64);


### PR DESCRIPTION
Rather than passing std::io::Write to async methods, define separate tokio/async-std/std versions of the `response_data_to_writer` method on `Request` to accept the proper sync/async Write trait for the environment