### PR TITLE
Make attohttpc optional for credentials

### DIFF
--- a/aws-creds/Cargo.toml
+++ b/aws-creds/Cargo.toml
@@ -26,10 +26,10 @@ serde_derive = "1"
 
 
 [features]
-default = ["http-credentials", "native-tls"]
+default = ["native-tls"]
 http-credentials = ["attohttpc"]
-native-tls = ["attohttpc/tls"]
-rustls-tls = ["attohttpc/tls-rustls"]
+native-tls = ["http-credentials", "attohttpc/tls"]
+rustls-tls = ["http-credentials", "attohttpc/tls-rustls"]
 
 [dev-dependencies]
 env_logger = "0.9"

--- a/aws-creds/Cargo.toml
+++ b/aws-creds/Cargo.toml
@@ -18,7 +18,7 @@ path = "src/lib.rs"
 anyhow = "1.0"
 dirs = "4"
 rust-ini = "0.17"
-attohttpc = { version = "0.17", default-features = false, features = ["json"] }
+attohttpc = { version = "0.17", default-features = false, features = ["json"], optional = true }
 url = "2"
 serde-xml-rs = "0.5"
 serde = "1"
@@ -26,7 +26,8 @@ serde_derive = "1"
 
 
 [features]
-default = ["native-tls"]
+default = ["http-credentials", "native-tls"]
+http-credentials = ["attohttpc"]
 native-tls = ["attohttpc/tls"]
 rustls-tls = ["attohttpc/tls-rustls"]
 

--- a/aws-creds/src/credentials.rs
+++ b/aws-creds/src/credentials.rs
@@ -124,6 +124,7 @@ static REQUEST_TIMEOUT_MS: AtomicU32 = AtomicU32::new(0);
 /// Short durations are bumped to one millisecond, and durations
 /// greater than 4 billion milliseconds (49 days) are rounded up to
 /// infinity (no timeout).
+#[cfg(feature = "http-credentials")]
 pub fn set_request_timeout(timeout: Option<Duration>) {
     use std::convert::TryInto;
     let duration_ms = timeout
@@ -138,6 +139,7 @@ pub fn set_request_timeout(timeout: Option<Duration>) {
 }
 
 /// Sends a GET request to `url` with a request timeout if one was set.
+#[cfg(feature = "http-credentials")]
 fn http_get(url: &str) -> attohttpc::Result<attohttpc::Response> {
     let mut builder = attohttpc::get(url);
 
@@ -150,6 +152,7 @@ fn http_get(url: &str) -> attohttpc::Result<attohttpc::Response> {
 }
 
 impl Credentials {
+    #[cfg(feature = "http-credentials")]
     pub fn from_sts_env(session_name: &str) -> Result<Credentials> {
         let role_arn = env::var("AWS_ROLE_ARN")?;
         let web_identity_token_file = env::var("AWS_WEB_IDENTITY_TOKEN_FILE")?;
@@ -157,6 +160,7 @@ impl Credentials {
         Credentials::from_sts(&role_arn, session_name, &web_identity_token)
     }
 
+    #[cfg(feature = "http-credentials")]
     pub fn from_sts(
         role_arn: &str,
         session_name: &str,
@@ -200,6 +204,7 @@ impl Credentials {
         })
     }
 
+    #[cfg(feature = "http-credentials")]
     pub fn default() -> Result<Credentials> {
         Credentials::new(None, None, None, None, None)
     }
@@ -215,6 +220,7 @@ impl Credentials {
 
     /// Initialize Credentials directly with key ID, secret key, and optional
     /// token.
+    #[cfg(feature = "http-credentials")]
     pub fn new(
         access_key: Option<&str>,
         secret_key: Option<&str>,
@@ -260,6 +266,7 @@ impl Credentials {
         Credentials::from_env_specific(None, None, None, None)
     }
 
+    #[cfg(feature = "http-credentials")]
     pub fn from_instance_metadata() -> Result<Credentials> {
         #[derive(Deserialize)]
         #[serde(rename_all = "PascalCase")]


### PR DESCRIPTION
If an application is simply constructing a Credentials struct from existing values for `rust-s3`, it doesn't need an http client bundled into the library. This change makes the http client in aws-creds optional behind a feature flag, but still enabled by default.