### PR TITLE
Make all fail-on-err variations run the same check

### DIFF
--- a/s3/src/blocking.rs
+++ b/s3/src/blocking.rs
@@ -81,7 +81,7 @@ impl<'a> Request for AttoRequest<'a> {
 
         let response = request.bytes(&self.request_body()).send()?;
 
-        if cfg!(feature = "fail-on-err") && response.status().as_u16() >= 400 {
+        if cfg!(feature = "fail-on-err") && !response.status().is_success() {
             return Err(anyhow!(
                 "Request failed with code {}\n{}",
                 response.status().as_u16(),

--- a/s3/src/request.rs
+++ b/s3/src/request.rs
@@ -93,7 +93,7 @@ impl<'a> Request for Reqwest<'a> {
 
         let response = request.send().await?;
 
-        if cfg!(feature = "fail-on-err") && response.status().as_u16() >= 400 {
+        if cfg!(feature = "fail-on-err") && !response.status().is_success() {
             return Err(anyhow!(
                 "Request failed with code {}\n{}",
                 response.status().as_u16(),


### PR DESCRIPTION
All 3 provided client implementations contain an `is_success` method for status codes, and the behavior of all 3 of those methods is the same, so this standardizes the behavior between the clients.