### PR TITLE
Make request methods generic over a new Client type

### DIFF
--- a/s3/Cargo.toml
+++ b/s3/Cargo.toml
@@ -45,7 +45,7 @@ serde-xml-rs = "0.5"
 sha2 = "0.10"
 thiserror = "1"
 surf = { version = "2", optional = true, default-features = false, features = ["h1-client-rustls"] }
-tokio = { version = "1", features = ["io-util"], optional = true, default-features = false }
+tokio = { version = "1", features = ["io-util" ], optional = true, default-features = false }
 tokio-stream = { version = "0.1", optional = true }
 url = "2"
 minidom = { version = "0.14", optional = true }
@@ -80,3 +80,4 @@ uuid = { version = "1", features = ["v4"] }
 env_logger = "0.9"
 # aws-creds = { version = "0.29", default-features = false }
 aws-creds = { path = "../aws-creds", features = ["http-credentials"] }
+anyhow = "1"

--- a/s3/Cargo.toml
+++ b/s3/Cargo.toml
@@ -22,8 +22,8 @@ path = "src/lib.rs"
 async-std = { version = "1", optional = true }
 async-trait = "0.1"
 attohttpc = { version = "0.19", optional = true, default-features = false }
-aws-creds = { version = "0.29", default-features = false }
-# aws-creds = { path = "../aws-creds", default-features = false }
+# aws-creds = { version = "0.29", default-features = false }
+aws-creds = { path = "../aws-creds", default-features = false }
 aws-region = "0.24"
 # aws-region = {path = "../aws-region"}
 base64 = "0.13"
@@ -53,10 +53,13 @@ minidom = { version = "0.14", optional = true }
 block_on_proc = { version = "0.2", optional = true }
 
 [features]
-with-tokio = ["reqwest", "tokio", "tokio/fs", "tokio-stream"]
-with-async-std = ["async-std", "surf", "futures-io", "futures-util"]
-sync = ["attohttpc", "maybe-async/is_sync"]
-default = ["tags", "tokio-native-tls"]
+with-tokio = ["tokio", "tokio/fs", "tokio-stream"]
+with-reqwest = ["reqwest", "with-tokio"]
+with-async-std = ["async-std", "futures-io", "futures-util"]
+with-surf = ["surf", "with-async-std"]
+sync = ["maybe-async/is_sync"]
+default = ["tags", "tokio-native-tls", "with-reqwest"]
+with-attohttpc = ["attohttpc", "sync"]
 no-verify-ssl = []
 fail-on-err = []
 tokio-native-tls = ["with-tokio", "reqwest/native-tls", "aws-creds/native-tls"]
@@ -71,6 +74,6 @@ tokio = { version = "1", features = ["rt", "rt-multi-thread", "macros", "fs"] }
 async-std = { version = "1", features = ["attributes"] }
 uuid = { version = "1", features = ["v4"] }
 env_logger = "0.9"
-aws-creds = { version = "0.29", default-features = false }
-# aws-creds = { path = "../aws-creds", features = ["http-credentials"] }
+# aws-creds = { version = "0.29", default-features = false }
+aws-creds = { path = "../aws-creds", features = ["http-credentials"] }
 anyhow = "1"

--- a/s3/Cargo.toml
+++ b/s3/Cargo.toml
@@ -81,3 +81,4 @@ env_logger = "0.9"
 # aws-creds = { version = "0.29", default-features = false }
 aws-creds = { path = "../aws-creds", features = ["http-credentials"] }
 anyhow = "1"
+reqwest = { version = "0.11", default-features = false, features = ["default-tls", "json", "stream"] }

--- a/s3/Cargo.toml
+++ b/s3/Cargo.toml
@@ -53,20 +53,24 @@ minidom = { version = "0.14", optional = true }
 block_on_proc = { version = "0.2", optional = true }
 
 [features]
-with-tokio = ["tokio", "tokio/fs", "tokio-stream"]
-with-reqwest = ["reqwest", "with-tokio"]
-with-async-std = ["async-std", "futures-io", "futures-util"]
-with-surf = ["surf", "with-async-std"]
-sync = ["maybe-async/is_sync"]
-default = ["tags", "tokio-native-tls", "with-reqwest"]
+default = ["tags", "with-reqwest"]
+
+# http clients
 with-attohttpc = ["attohttpc", "sync"]
-no-verify-ssl = []
-fail-on-err = []
-tokio-native-tls = ["with-tokio", "reqwest/native-tls", "aws-creds/native-tls"]
-tokio-rustls-tls = ["with-tokio", "reqwest/rustls-tls", "aws-creds/rustls-tls"]
-sync-native-tls = ["sync", "aws-creds/native-tls", "attohttpc/tls"]
-sync-rustls-tls = ["sync", "aws-creds/rustls-tls", "attohttpc/tls-rustls"]
+with-reqwest = ["reqwest", "with-tokio"]
+with-surf = ["surf", "with-async-std"]
+
+# runtimes
+sync = ["maybe-async/is_sync"]
+with-tokio = ["tokio", "tokio/fs", "tokio-stream"]
+with-async-std = ["async-std", "futures-io"]
 blocking = ["block_on_proc", "tokio/rt", "tokio/rt-multi-thread"]
+
+fail-on-err = []
+creds-http = ["aws-creds/http-credentials"]
+creds-native-tls = ["aws-creds/native-tls"]
+creds-rustls-tls = ["aws-creds/rustls-tls"]
+never-encode-slash = []
 tags = ["minidom"]
 
 [dev-dependencies]
@@ -76,4 +80,3 @@ uuid = { version = "1", features = ["v4"] }
 env_logger = "0.9"
 # aws-creds = { version = "0.29", default-features = false }
 aws-creds = { path = "../aws-creds", features = ["http-credentials"] }
-anyhow = "1"

--- a/s3/Makefile
+++ b/s3/Makefile
@@ -1,43 +1,32 @@
 async-all: tokio async-std
-sync-all: sync-nativetls sync-rustlstls sync-nossl
+sync-all: sync
 test-all: fmt-check async-all sync-all
 ci: clippy fmt-check tokio-not-ignored async-std-test-not-ignored
 
 clippy: tokio-clippy async-std-clippy sync-clippy
-tokio-clippy: tokio-nativetls-clippy tokio-nossl-clippy tokio-rustlstls-clippy
-sync-clippy: sync-nativetls-clippy sync-nossl-clippy sync-rustlstls-clippy
+tokio-clippy: tokio-noclient-clippy reqwest-clippy
+sync-clippy: sync-noclient-clippy attohttpc-clippy
 
 # tokio
-tokio: tokio-nativetls tokio-nossl tokio-rustlstls
-tokio-not-ignored: tokio-nativetls-test-not-ignored tokio-nossl-test-not-ignored tokio-rustlstls-test-not-ignored
+tokio: tokio-noclient reqwest
+tokio-not-ignored: tokio-noclient-test-not-ignored reqwest-test-not-ignored
 
-tokio-nativetls: tokio-nativetls-clippy tokio-nativetls-test tokio-nativetls-blocking-test-ignored
-tokio-nativetls-clippy:
-	cargo clippy -- -D warnings
-tokio-nativetls-test: tokio-nativetls-test-not-ignored tokio-nativetls-test-ignored
-tokio-nativetls-test-not-ignored:
-	cargo test
-tokio-nativetls-test-ignored:
-	cargo test -- --ignored
-tokio-nativetls-blocking-test-ignored:
-	cargo test --features blocking -- --ignored
-
-tokio-nossl: tokio-nossl-test-not-ignored tokio-nossl-clippy
-tokio-nossl-clippy:
+tokio-noclient: tokio-noclient-test-not-ignored tokio-noclient-clippy
+tokio-noclient-clippy:
 	cargo clippy --no-default-features --features with-tokio -- -D warnings
-tokio-nossl-test-not-ignored:
+tokio-noclient-test-not-ignored:
 	cargo test --no-default-features --features with-tokio
 
-tokio-rustlstls: tokio-rustlstls-test-not-ignored tokio-rustlstls-test-ignored tokio-rustlstls-clippy
-tokio-rustlstls-clippy:
-	cargo clippy --no-default-features --features with-tokio --features tokio-rustls-tls -- -D warnings
-tokio-rustlstls-test-not-ignored:
-	cargo test --no-default-features --features with-tokio --features tokio-rustls-tls
-tokio-rustlstls-test-ignored:
-	cargo test --no-default-features --features with-tokio --features tokio-rustls-tls -- --ignored
+reqwest: reqwest-clippy reqwest-test-not-ignored request-test-blocking-ignored
+reqwest-clippy:
+	cargo clippy --no-default-features --features with-reqwest -- -D warnings
+reqwest-test-not-ignored:
+	cargo test --no-default-features --features with-reqwest
+request-test-blocking-ignored:
+	cargo test --no-default-features --features with-reqwest,blocking -- --ignored
 
 # async-std
-async-std: async-std-clippy async-std-test async-std-clippy
+async-std: async-std-clippy async-std-test async-std-clippy surf
 async-std-clippy:
 	cargo clippy --no-default-features --features with-async-std -- -D warnings
 async-std-test: async-std-test-not-ignored async-std-test-ignored async-std-test-blocking-ignored
@@ -48,24 +37,25 @@ async-std-test-ignored:
 async-std-test-blocking-ignored:
 	cargo test --no-default-features --features with-async-std --features blocking -- --ignored
 
+surf: surf-clippy surf-test-not-ignored surf-test-blocking-ignored
+surf-clippy:
+	cargo clippy --no-default-features --features with-surf -- -D warnings
+surf-test-not-ignored:
+	cargo test --no-default-features --features with-surf
+surf-test-blocking-ignored:
+	cargo test --no-default-features --features with-surf,blocking -- --ignored
+
 # sync
-sync-nativetls: sync-nativetls-clippy sync-nativetls-test
-sync-nativetls-clippy:
-	cargo clippy --no-default-features --features sync --features sync-native-tls -- -D warnings
-sync-nativetls-test: sync-nativetls-test-ignored
-sync-nativetls-test-ignored:
-	cargo test --no-default-features --features sync --features sync-native-tls -- --ignored
-
-sync-rustlstls: sync-rustlstls-clippy sync-rustlstls-test
-sync-rustlstls-clippy:
-	cargo clippy --no-default-features --features sync --features sync-rustls-tls -- -D warnings
-sync-rustlstls-test: sync-rustlstls-test-ignored
-sync-rustlstls-test-ignored:
-	cargo test --no-default-features --features sync --features sync-rustls-tls -- --ignored
-
-sync-nossl: sync-nossl-clippy
-sync-nossl-clippy:
+sync: sync-noclient attohttpc
+sync-noclient: sync-noclient-clippy
+sync-noclient-clippy:
 	cargo clippy --no-default-features --features sync -- -D warnings
+
+attohttpc: attohttpc-clippy attohttpc-test-not-ignored
+attohttpc-clippy:
+	cargo clippy --no-default-features --features with-attohttpc -- -D warnings
+attohttpc-test-not-ignored:
+	cargo test --no-default-features --features with-attohttpc
 
 fmt: 
 	cargo fmt

--- a/s3/Makefile
+++ b/s3/Makefile
@@ -1,7 +1,7 @@
 async-all: tokio async-std
 sync-all: sync
 test-all: fmt-check async-all sync-all
-ci: clippy fmt-check tokio-not-ignored async-std-test-not-ignored
+ci: clippy fmt-check tokio-not-ignored async-std-not-ignored sync-not-ignored
 
 clippy: tokio-clippy async-std-clippy sync-clippy
 tokio-clippy: tokio-noclient-clippy reqwest-clippy
@@ -27,6 +27,7 @@ request-test-blocking-ignored:
 
 # async-std
 async-std: async-std-clippy async-std-test async-std-clippy surf
+async-std-not-ignored: async-std-test-not-ignored surf-test-not-ignored
 async-std-clippy:
 	cargo clippy --no-default-features --features with-async-std -- -D warnings
 async-std-test: async-std-test-not-ignored async-std-test-ignored async-std-test-blocking-ignored
@@ -47,9 +48,12 @@ surf-test-blocking-ignored:
 
 # sync
 sync: sync-noclient attohttpc
-sync-noclient: sync-noclient-clippy
+sync-not-ignored: sync-test-not-ignored attohttpc-test-not-ignored
+sync-noclient: sync-noclient-clippy sync-test-not-ignored
 sync-noclient-clippy:
 	cargo clippy --no-default-features --features sync -- -D warnings
+sync-test-not-ignored:
+	cargo test --no-default-features --features sync
 
 attohttpc: attohttpc-clippy attohttpc-test-not-ignored
 attohttpc-clippy:

--- a/s3/Makefile
+++ b/s3/Makefile
@@ -4,12 +4,12 @@ test-all: fmt-check async-all sync-all
 ci: clippy fmt-check tokio-not-ignored async-std-test-not-ignored
 
 clippy: tokio-clippy async-std-clippy sync-clippy
-tokio-clippy: tokio-nativetls-clippy tokio-nossl-clippy tokio-noverify-clippy tokio-rustlstls-clippy
+tokio-clippy: tokio-nativetls-clippy tokio-nossl-clippy tokio-rustlstls-clippy
 sync-clippy: sync-nativetls-clippy sync-nossl-clippy sync-rustlstls-clippy
 
 # tokio
-tokio: tokio-nativetls tokio-nossl tokio-noverify tokio-rustlstls
-tokio-not-ignored: tokio-nativetls-test-not-ignored tokio-nossl-test-not-ignored tokio-noverify-test-not-ignored tokio-rustlstls-test-not-ignored
+tokio: tokio-nativetls tokio-nossl tokio-rustlstls
+tokio-not-ignored: tokio-nativetls-test-not-ignored tokio-nossl-test-not-ignored tokio-rustlstls-test-not-ignored
 
 tokio-nativetls: tokio-nativetls-clippy tokio-nativetls-test tokio-nativetls-blocking-test-ignored
 tokio-nativetls-clippy:
@@ -27,12 +27,6 @@ tokio-nossl-clippy:
 	cargo clippy --no-default-features --features with-tokio -- -D warnings
 tokio-nossl-test-not-ignored:
 	cargo test --no-default-features --features with-tokio
-
-tokio-noverify: tokio-noverify-test-not-ignored tokio-noverify-clippy
-tokio-noverify-clippy:
-	cargo clippy --no-default-features --features with-tokio --features no-verify-ssl -- -D warnings
-tokio-noverify-test-not-ignored:
-	cargo test --no-default-features --features with-tokio --features no-verify-ssl
 
 tokio-rustlstls: tokio-rustlstls-test-not-ignored tokio-rustlstls-test-ignored tokio-rustlstls-clippy
 tokio-rustlstls-clippy:

--- a/s3/src/blocking.rs
+++ b/s3/src/blocking.rs
@@ -172,7 +172,7 @@ mod tests {
     #[test]
     fn url_uses_https_by_default_path_style() -> Result<()> {
         let region = "custom-region".parse()?;
-        let bucket = Bucket::new_with_path_style("my-first-bucket", region, fake_credentials())?;
+        let bucket = Bucket::new("my-first-bucket", region, fake_credentials())?.with_path_style();
         let path = "/my-first/path";
         let request = AttoRequest::new(&bucket, path, Command::GetObject);
 
@@ -203,7 +203,7 @@ mod tests {
     #[test]
     fn url_uses_scheme_from_custom_region_if_defined_with_path_style() -> Result<()> {
         let region = "http://custom-region".parse()?;
-        let bucket = Bucket::new_with_path_style("my-second-bucket", region, fake_credentials())?;
+        let bucket = Bucket::new("my-second-bucket", region, fake_credentials())?.with_path_style();
         let path = "/my-second/path";
         let request = AttoRequest::new(&bucket, path, Command::GetObject);
 

--- a/s3/src/bucket.rs
+++ b/s3/src/bucket.rs
@@ -117,7 +117,9 @@ impl Bucket {
     /// let bucket = Bucket::new(bucket_name, region, credentials).unwrap();
     ///
     /// // Add optional custom queries
+    /// #[cfg(any(feature = "with-attohttpc", feature = "with-surf", feature = "with-reqwest"))]
     /// let mut custom_queries = HashMap::new();
+    /// #[cfg(any(feature = "with-attohttpc", feature = "with-surf", feature = "with-reqwest"))]
     /// custom_queries.insert(
     ///    "response-content-disposition".into(),
     ///    "attachment; filename=\"test.png\"".into(),
@@ -130,7 +132,12 @@ impl Bucket {
     /// #[cfg(feature = "with-attohttpc")]
     /// let client = attohttpc::Session::new();
     ///
+    /// #[cfg(any(feature = "with-surf", feature = "with-reqwest"))]
     /// let url = bucket.presign_get(&client, "/test.file", 86400, Some(custom_queries)).unwrap();
+    /// #[cfg(feature = "with-attohttpc")]
+    /// let url = bucket.presign_get(&client, "/test.file", 86400, Some(custom_queries)).unwrap();
+    ///
+    /// #[cfg(any(feature = "with-attohttpc", feature = "with-surf", feature = "with-reqwest"))]
     /// println!("Presigned url: {}", url);
     /// ```
     pub fn presign_get<C: for<'a> Client<'a>, S: AsRef<str>>(
@@ -180,7 +187,12 @@ impl Bucket {
     ///    "custom_value".parse().unwrap(),
     /// );
     ///
+    /// #[cfg(any(feature = "with-reqwest", feature = "with-surf"))]
     /// let url = bucket.presign_put(&client, "/test.file", 86400, Some(custom_headers)).unwrap();
+    /// #[cfg(feature = "with-attohttpc")]
+    /// let url = bucket.presign_put(&client, "/test.file", 86400, Some(custom_headers)).unwrap();
+    ///
+    /// #[cfg(any(feature = "with-attohttpc", feature = "with-surf", feature = "with-reqwest"))]
     /// println!("Presigned url: {}", url);
     /// ```
     pub fn presign_put<C: for<'a> Client<'a>, S: AsRef<str>>(
@@ -221,7 +233,13 @@ impl Bucket {
     /// #[cfg(feature = "with-attohttpc")]
     /// let client = attohttpc::Session::new();
     ///
+    /// #[cfg(any(feature = "with-reqwest", feature = "with-surf"))]
     /// let url = bucket.presign_delete(&client, "/test.file", 86400).unwrap();
+    ///
+    /// #[cfg(feature = "with-attohttpc")]
+    /// let url = bucket.presign_delete(&client, "/test.file", 86400).unwrap();
+    ///
+    /// #[cfg(any(feature = "with-attohttpc", feature = "with-surf", feature = "with-reqwest"))]
     /// println!("Presigned url: {}", url);
     /// ```
     pub fn presign_delete<C: for<'a> Client<'a>, S: AsRef<str>>(
@@ -246,6 +264,7 @@ impl Bucket {
     /// # #[tokio::main]
     /// # async fn main() -> Result<()> {
     /// let bucket_name = "rust-s3-test";
+    /// #[cfg(any(feature = "with-attohttpc", feature = "with-surf", feature = "with-reqwest"))]
     /// let region = "us-east-1".parse()?;
     /// let credentials = Credentials::default()?;
     /// let config = BucketConfiguration::default();
@@ -269,7 +288,7 @@ impl Bucket {
     /// # let config = BucketConfiguration::default();
     /// // Blocking variant, generated with `blocking` feature in combination
     /// // with `tokio` or `async-std` features.
-    /// #[cfg(feature = "blocking")]
+    /// #[cfg(all(feature = "blocking", any(feature = "with-reqwest", feature = "with-surf")))]
     /// let create_bucket_response = Bucket::create_blocking(&client, bucket_name, region, credentials, config)?;
     /// # Ok(())
     /// # }
@@ -308,6 +327,7 @@ impl Bucket {
     /// # #[tokio::main]
     /// # async fn main() -> Result<()> {
     /// let bucket_name = "rust-s3-test";
+    /// #[cfg(any(feature = "with-attohttpc", feature = "with-surf", feature = "with-reqwest"))]
     /// let region = "us-east-1".parse()?;
     /// let credentials = Credentials::default()?;
     /// let config = BucketConfiguration::default();
@@ -331,7 +351,7 @@ impl Bucket {
     /// # let config = BucketConfiguration::default();
     /// // Blocking variant, generated with `blocking` feature in combination
     /// // with `tokio` or `async-std` features.
-    /// #[cfg(feature = "blocking")]
+    /// #[cfg(all(feature = "blocking", any(feature = "with-reqwest", feature = "with-surf")))]
     /// let create_bucket_response = Bucket::create_with_path_style_blocking(&client, bucket_name, region, credentials, config)?;
     /// # Ok(())
     /// # }
@@ -2781,6 +2801,7 @@ mod test {
     }
 
     #[test]
+    #[ignore]
     fn test_builder_composition() {
         use std::time::Duration;
 

--- a/s3/src/bucket.rs
+++ b/s3/src/bucket.rs
@@ -2311,7 +2311,7 @@ mod test {
     #[ignore]
     #[maybe_async::test(
         feature = "sync",
-        async(all(not(feature = "sync"), feature = "with-tokio"), tokio::test),
+        async(all(not(feature = "sync"), not(feature = "tokio-rustls-tls"), feature = "with-tokio"), tokio::test),
         async(
             all(not(feature = "sync"), feature = "with-async-std"),
             async_std::test
@@ -2343,7 +2343,7 @@ mod test {
     #[ignore]
     #[maybe_async::test(
         feature = "sync",
-        async(all(not(feature = "sync"), feature = "with-tokio"), tokio::test),
+        async(all(not(feature = "sync"), not(feature = "tokio-rustls-tls"), feature = "with-tokio"), tokio::test),
         async(
             all(not(feature = "sync"), feature = "with-async-std"),
             async_std::test

--- a/s3/src/bucket.rs
+++ b/s3/src/bucket.rs
@@ -2201,12 +2201,9 @@ mod test {
     #[ignore]
     #[cfg(feature = "tags")]
     #[maybe_async::test(
-        feature = "sync",
-        async(all(not(feature = "sync"), feature = "with-tokio"), tokio::test),
-        async(
-            all(not(feature = "sync"), feature = "with-async-std"),
-            async_std::test
-        )
+        feature = "with-attohttpc",
+        async(all(not(feature = "sync"), feature = "with-reqwest"), tokio::test),
+        async(all(not(feature = "sync"), feature = "with-surf"), async_std::test)
     )]
     async fn test_tagging_aws() {
         let client = make_client();
@@ -2374,19 +2371,9 @@ mod test {
     /// This should be optimized into a plain PUT, not a multi-part upload.
     #[ignore]
     #[maybe_async::test(
-        feature = "sync",
-        async(
-            all(
-                not(feature = "sync"),
-                not(feature = "tokio-rustls-tls"),
-                feature = "with-tokio"
-            ),
-            tokio::test
-        ),
-        async(
-            all(not(feature = "sync"), feature = "with-async-std"),
-            async_std::test
-        )
+        feature = "with-attohttpc",
+        async(all(not(feature = "sync"), feature = "with-reqwest"), tokio::test),
+        async(all(not(feature = "sync"), feature = "with-surf"), async_std::test)
     )]
     async fn streaming_test_put_get_delete_small_object() {
         init();
@@ -2421,7 +2408,14 @@ mod test {
         assert_eq!(code, 204);
     }
 
-    #[cfg(feature = "blocking")]
+    #[cfg(all(
+        feature = "blocking",
+        any(
+            feature = "with-attohttpc",
+            feature = "with-reqwest",
+            feature = "with-surf"
+        )
+    ))]
     fn put_head_get_list_delete_object_blocking(bucket: Bucket) {
         let client = make_client();
 
@@ -2542,7 +2536,7 @@ mod test {
 
     #[ignore]
     #[cfg(all(
-        any(feature = "with-tokio", feature = "with-async-std"),
+        any(feature = "with-reqwest", feature = "with-surf"),
         feature = "blocking"
     ))]
     #[test]
@@ -2574,19 +2568,9 @@ mod test {
 
     #[ignore]
     #[maybe_async::test(
-        feature = "sync",
-        async(
-            all(
-                not(feature = "sync"),
-                not(feature = "tokio-rustls-tls"),
-                feature = "with-tokio"
-            ),
-            tokio::test
-        ),
-        async(
-            all(not(feature = "sync"), feature = "with-async-std"),
-            async_std::test
-        )
+        feature = "with-attohttpc",
+        async(all(not(feature = "sync"), feature = "with-reqwest"), tokio::test),
+        async(all(not(feature = "sync"), feature = "with-surf"), async_std::test)
     )]
     async fn aws_put_head_get_delete_object() {
         let client = make_client();
@@ -2595,12 +2579,9 @@ mod test {
 
     #[ignore]
     #[maybe_async::test(
-        feature = "sync",
-        async(all(not(feature = "sync"), feature = "with-tokio"), tokio::test),
-        async(
-            all(not(feature = "sync"), feature = "with-async-std"),
-            async_std::test
-        )
+        feature = "with-attohttpc",
+        async(all(not(feature = "sync"), feature = "with-reqwest"), tokio::test),
+        async(all(not(feature = "sync"), feature = "with-surf"), async_std::test)
     )]
     async fn gc_test_put_head_get_delete_object() {
         let client = make_client();
@@ -2609,19 +2590,9 @@ mod test {
 
     #[ignore]
     #[maybe_async::test(
-        feature = "sync",
-        async(
-            all(
-                not(feature = "sync"),
-                not(feature = "tokio-rustls-tls"),
-                feature = "with-tokio"
-            ),
-            tokio::test
-        ),
-        async(
-            all(not(feature = "sync"), feature = "with-async-std"),
-            async_std::test
-        )
+        feature = "with-attohttpc",
+        async(all(not(feature = "sync"), feature = "with-reqwest"), tokio::test),
+        async(all(not(feature = "sync"), feature = "with-surf"), async_std::test)
     )]
     async fn wasabi_test_put_head_get_delete_object() {
         let client = make_client();
@@ -2630,12 +2601,9 @@ mod test {
 
     #[ignore]
     #[maybe_async::test(
-        feature = "sync",
-        async(all(not(feature = "sync"), feature = "with-tokio"), tokio::test),
-        async(
-            all(not(feature = "sync"), feature = "with-async-std"),
-            async_std::test
-        )
+        feature = "with-attohttpc",
+        async(all(not(feature = "sync"), feature = "with-reqwest"), tokio::test),
+        async(all(not(feature = "sync"), feature = "with-surf"), async_std::test)
     )]
     async fn minio_test_put_head_get_delete_object() {
         let client = make_client();
@@ -2657,21 +2625,22 @@ mod test {
 
     #[ignore]
     #[maybe_async::test(
-        feature = "sync",
-        async(all(not(feature = "sync"), feature = "with-tokio"), tokio::test),
-        async(
-            all(not(feature = "sync"), feature = "with-async-std"),
-            async_std::test
-        )
+        feature = "with-attohttpc",
+        async(all(not(feature = "sync"), feature = "with-reqwest"), tokio::test),
+        async(all(not(feature = "sync"), feature = "with-surf"), async_std::test)
     )]
     async fn digital_ocean_test_put_head_get_delete_object() {
         let client = make_client();
         put_head_get_delete_object(&client, test_digital_ocean_bucket()).await;
     }
 
-    #[test]
+    #[maybe_async::test(
+        feature = "with-attohttpc",
+        async(all(not(feature = "sync"), feature = "with-reqwest"), tokio::test),
+        async(all(not(feature = "sync"), feature = "with-surf"), async_std::test)
+    )]
     #[ignore]
-    fn test_presign_put() {
+    async fn test_presign_put() {
         let s3_path = "/test/test.file";
         let bucket = test_aws_bucket();
         let client = make_client();
@@ -2690,9 +2659,13 @@ mod test {
         assert!(url.contains("/test/test.file"))
     }
 
-    #[test]
+    #[maybe_async::test(
+        feature = "with-attohttpc",
+        async(all(not(feature = "sync"), feature = "with-reqwest"), tokio::test),
+        async(all(not(feature = "sync"), feature = "with-surf"), async_std::test)
+    )]
     #[ignore]
-    fn test_presign_get() {
+    async fn test_presign_get() {
         let s3_path = "/test/test.file";
         let bucket = test_aws_bucket();
         let client = make_client();
@@ -2701,9 +2674,13 @@ mod test {
         assert!(url.contains("/test/test.file?"))
     }
 
-    #[test]
+    #[maybe_async::test(
+        feature = "with-attohttpc",
+        async(all(not(feature = "sync"), feature = "with-reqwest"), tokio::test),
+        async(all(not(feature = "sync"), feature = "with-surf"), async_std::test)
+    )]
     #[ignore]
-    fn test_presign_delete() {
+    async fn test_presign_delete() {
         let s3_path = "/test/test.file";
         let bucket = test_aws_bucket();
         let client = make_client();
@@ -2713,12 +2690,9 @@ mod test {
     }
 
     #[maybe_async::test(
-        feature = "sync",
-        async(all(not(feature = "sync"), feature = "with-tokio"), tokio::test),
-        async(
-            all(not(feature = "sync"), feature = "with-async-std"),
-            async_std::test
-        )
+        feature = "with-attohttpc",
+        async(all(not(feature = "sync"), feature = "with-reqwest"), tokio::test),
+        async(all(not(feature = "sync"), feature = "with-surf"), async_std::test)
     )]
     #[ignore]
     async fn test_bucket_create_delete_default_region() {
@@ -2744,12 +2718,9 @@ mod test {
 
     #[ignore]
     #[maybe_async::test(
-        feature = "sync",
-        async(all(not(feature = "sync"), feature = "with-tokio"), tokio::test),
-        async(
-            all(not(feature = "sync"), feature = "with-async-std"),
-            async_std::test
-        )
+        feature = "with-attohttpc",
+        async(all(not(feature = "sync"), feature = "with-reqwest"), tokio::test),
+        async(all(not(feature = "sync"), feature = "with-surf"), async_std::test)
     )]
     async fn test_bucket_create_delete_non_default_region() {
         let client = make_client();
@@ -2775,12 +2746,9 @@ mod test {
 
     #[ignore]
     #[maybe_async::test(
-        feature = "sync",
-        async(all(not(feature = "sync"), feature = "with-tokio"), tokio::test),
-        async(
-            all(not(feature = "sync"), feature = "with-async-std"),
-            async_std::test
-        )
+        feature = "with-attohttpc",
+        async(all(not(feature = "sync"), feature = "with-reqwest"), tokio::test),
+        async(all(not(feature = "sync"), feature = "with-surf"), async_std::test)
     )]
     async fn test_bucket_create_delete_non_default_region_public() {
         let client = make_client();

--- a/s3/src/bucket.rs
+++ b/s3/src/bucket.rs
@@ -128,7 +128,7 @@ impl Bucket {
     /// #[cfg(feature = "with-surf")]
     /// let client = surf::Client::new();;
     /// #[cfg(feature = "with-attohttpc")]
-    /// let client = s3::client::AttoHttpClient;
+    /// let client = attohttpc::Session::new();
     ///
     /// let url = bucket.presign_get(&client, "/test.file", 86400, Some(custom_queries)).unwrap();
     /// println!("Presigned url: {}", url);
@@ -171,7 +171,7 @@ impl Bucket {
     /// #[cfg(feature = "with-surf")]
     /// let client = surf::Client::new();;
     /// #[cfg(feature = "with-attohttpc")]
-    /// let client = s3::client::AttoHttpClient;
+    /// let client = attohttpc::Session::new();
     ///
     /// // Add optional custom headers
     /// let mut custom_headers = HeaderMap::new();
@@ -219,7 +219,7 @@ impl Bucket {
     /// #[cfg(feature = "with-surf")]
     /// let client = surf::Client::new();;
     /// #[cfg(feature = "with-attohttpc")]
-    /// let client = s3::client::AttoHttpClient;
+    /// let client = attohttpc::Session::new();
     ///
     /// let url = bucket.presign_delete(&client, "/test.file", 86400).unwrap();
     /// println!("Presigned url: {}", url);
@@ -254,7 +254,7 @@ impl Bucket {
     /// #[cfg(feature = "with-surf")]
     /// let client = surf::Client::new();;
     /// #[cfg(feature = "with-attohttpc")]
-    /// let client = s3::client::AttoHttpClient;
+    /// let client = attohttpc::Session::new();
     ///
     /// // Async variant with `tokio` or `async-std` features
     /// #[cfg(any(feature = "with-reqwest", feature = "with-surf"))]
@@ -316,7 +316,7 @@ impl Bucket {
     /// #[cfg(feature = "with-surf")]
     /// let client = surf::Client::new();;
     /// #[cfg(feature = "with-attohttpc")]
-    /// let client = s3::client::AttoHttpClient;
+    /// let client = attohttpc::Session::new();
     ///
     /// // Async variant with `tokio` or `async-std` features
     /// #[cfg(any(feature = "with-reqwest", feature = "with-surf"))]
@@ -378,7 +378,7 @@ impl Bucket {
     /// #[cfg(feature = "with-surf")]
     /// let client = surf::Client::new();;
     /// #[cfg(feature = "with-attohttpc")]
-    /// let client = s3::client::AttoHttpClient;
+    /// let client = attohttpc::Session::new();
     ///
     /// // Async variant with `tokio` or `async-std` features
     /// #[cfg(any(feature = "with-reqwest", feature = "with-surf"))]
@@ -605,7 +605,7 @@ impl Bucket {
     /// #[cfg(feature = "with-surf")]
     /// let client = surf::Client::new();;
     /// #[cfg(feature = "with-attohttpc")]
-    /// let client = s3::client::AttoHttpClient;
+    /// let client = attohttpc::Session::new();
     ///
     /// // Async variant with `tokio` or `async-std` features
     /// #[cfg(any(feature = "with-reqwest", feature = "with-surf"))]
@@ -669,7 +669,7 @@ impl Bucket {
     /// #[cfg(feature = "with-surf")]
     /// let client = surf::Client::new();;
     /// #[cfg(feature = "with-attohttpc")]
-    /// let client = s3::client::AttoHttpClient;
+    /// let client = attohttpc::Session::new();
     ///
     /// // Async variant with `tokio` or `async-std` features
     /// #[cfg(any(feature = "with-reqwest", feature = "with-surf"))]
@@ -718,7 +718,7 @@ impl Bucket {
     /// #[cfg(feature = "with-surf")]
     /// let client = surf::Client::new();;
     /// #[cfg(feature = "with-attohttpc")]
-    /// let client = s3::client::AttoHttpClient;
+    /// let client = attohttpc::Session::new();
     ///
     /// // Async variant with `tokio` or `async-std` features
     /// #[cfg(any(feature = "with-reqwest", feature = "with-surf"))]
@@ -767,7 +767,7 @@ impl Bucket {
     /// #[cfg(feature = "with-surf")]
     /// let client = surf::Client::new();;
     /// #[cfg(feature = "with-attohttpc")]
-    /// let client = s3::client::AttoHttpClient;
+    /// let client = attohttpc::Session::new();
     ///
     /// // Async variant with `tokio` or `async-std` features
     /// #[cfg(any(feature = "with-reqwest", feature = "with-surf"))]
@@ -819,12 +819,14 @@ impl Bucket {
     /// let region = "us-east-1".parse()?;
     /// let credentials = Credentials::default()?;
     /// let bucket = Bucket::new(bucket_name, region, credentials)?;
+    ///
     /// #[cfg(feature = "with-reqwest")]
     /// let client = reqwest::Client::new();
     /// #[cfg(feature = "with-surf")]
     /// let client = surf::Client::new();;
     /// #[cfg(feature = "with-attohttpc")]
-    /// let client = s3::client::AttoHttpClient;
+    /// let client = attohttpc::Session::new();
+    ///
     /// #[cfg(feature = "sync")]
     /// let mut output_file = File::create("output_file").expect("Unable to create file");
     /// #[cfg(feature = "with-tokio")]
@@ -903,7 +905,7 @@ impl Bucket {
     /// #[cfg(feature = "with-surf")]
     /// let client = surf::Client::new();;
     /// #[cfg(feature = "with-attohttpc")]
-    /// let client = s3::client::AttoHttpClient;
+    /// let client = attohttpc::Session::new();
     ///
     /// #[cfg(feature = "with-reqwest")]
     /// let mut path = tokio::fs::File::open(path).await?;
@@ -1126,7 +1128,7 @@ impl Bucket {
     /// #[cfg(feature = "with-surf")]
     /// let client = surf::Client::new();;
     /// #[cfg(feature = "with-attohttpc")]
-    /// let client = s3::client::AttoHttpClient;
+    /// let client = attohttpc::Session::new();
     ///
     /// // Async variant with `tokio` or `async-std` features
     /// #[cfg(any(feature = "with-reqwest", feature = "with-surf"))]
@@ -1190,7 +1192,7 @@ impl Bucket {
     /// #[cfg(feature = "with-surf")]
     /// let client = surf::Client::new();;
     /// #[cfg(feature = "with-attohttpc")]
-    /// let client = s3::client::AttoHttpClient;
+    /// let client = attohttpc::Session::new();
     ///
     /// let bucket_name = "rust-s3-test";
     /// let region = "us-east-1".parse()?;
@@ -1245,7 +1247,7 @@ impl Bucket {
     /// #[cfg(feature = "with-surf")]
     /// let client = surf::Client::new();;
     /// #[cfg(feature = "with-attohttpc")]
-    /// let client = s3::client::AttoHttpClient;
+    /// let client = attohttpc::Session::new();
     ///
     /// // Async variant with `tokio` or `async-std` features
     /// #[cfg(any(feature = "with-reqwest", feature = "with-surf"))]
@@ -1301,7 +1303,7 @@ impl Bucket {
     /// #[cfg(feature = "with-surf")]
     /// let client = surf::Client::new();;
     /// #[cfg(feature = "with-attohttpc")]
-    /// let client = s3::client::AttoHttpClient;
+    /// let client = attohttpc::Session::new();
     ///
     /// // Async variant with `tokio` or `async-std` features
     /// #[cfg(any(feature = "with-reqwest", feature = "with-surf"))]
@@ -1358,7 +1360,7 @@ impl Bucket {
     /// #[cfg(feature = "with-surf")]
     /// let client = surf::Client::new();;
     /// #[cfg(feature = "with-attohttpc")]
-    /// let client = s3::client::AttoHttpClient;
+    /// let client = attohttpc::Session::new();
     ///
     /// // Async variant with `tokio` or `async-std` features
     /// #[cfg(any(feature = "with-reqwest", feature = "with-surf"))]
@@ -1429,7 +1431,7 @@ impl Bucket {
     /// #[cfg(feature = "with-surf")]
     /// let client = surf::Client::new();;
     /// #[cfg(feature = "with-attohttpc")]
-    /// let client = s3::client::AttoHttpClient;
+    /// let client = attohttpc::Session::new();
     ///
     /// // Async variant with `tokio` or `async-std` features
     /// #[cfg(any(feature = "with-reqwest", feature = "with-surf"))]
@@ -1481,7 +1483,7 @@ impl Bucket {
     /// #[cfg(feature = "with-surf")]
     /// let client = surf::Client::new();;
     /// #[cfg(feature = "with-attohttpc")]
-    /// let client = s3::client::AttoHttpClient;
+    /// let client = attohttpc::Session::new();
     ///
     /// // Async variant with `tokio` or `async-std` features
     /// #[cfg(any(feature = "with-reqwest", feature = "with-surf"))]
@@ -1531,7 +1533,7 @@ impl Bucket {
     /// #[cfg(feature = "with-surf")]
     /// let client = surf::Client::new();;
     /// #[cfg(feature = "with-attohttpc")]
-    /// let client = s3::client::AttoHttpClient;
+    /// let client = attohttpc::Session::new();
     ///
     /// // Async variant with `tokio` or `async-std` features
     /// #[cfg(any(feature = "with-reqwest", feature = "with-surf"))]
@@ -1648,7 +1650,7 @@ impl Bucket {
     /// #[cfg(feature = "with-surf")]
     /// let client = surf::Client::new();;
     /// #[cfg(feature = "with-attohttpc")]
-    /// let client = s3::client::AttoHttpClient;
+    /// let client = attohttpc::Session::new();
     ///
     /// // Async variant with `tokio` or `async-std` features
     /// #[cfg(any(feature = "with-reqwest", feature = "with-surf"))]
@@ -1742,7 +1744,7 @@ impl Bucket {
     /// #[cfg(feature = "with-surf")]
     /// let client = surf::Client::new();;
     /// #[cfg(feature = "with-attohttpc")]
-    /// let client = s3::client::AttoHttpClient;
+    /// let client = attohttpc::Session::new();
     ///
     /// // Async variant with `tokio` or `async-std` features
     /// #[cfg(any(feature = "with-reqwest", feature = "with-surf"))]
@@ -1809,7 +1811,7 @@ impl Bucket {
     /// #[cfg(feature = "with-surf")]
     /// let client = surf::Client::new();;
     /// #[cfg(feature = "with-attohttpc")]
-    /// let client = s3::client::AttoHttpClient;
+    /// let client = attohttpc::Session::new();
     ///
     /// // Async variant with `tokio` or `async-std` features
     /// #[cfg(any(feature = "with-reqwest", feature = "with-surf"))]
@@ -2052,8 +2054,8 @@ mod test {
     }
 
     #[cfg(feature = "with-attohttpc")]
-    fn make_client() -> crate::client::AttoHttpClient {
-        crate::client::AttoHttpClient
+    fn make_client() -> attohttpc::Session {
+        attohttpc::Session::new()
     }
 
     fn init() {
@@ -2594,13 +2596,7 @@ mod test {
     #[ignore]
     #[maybe_async::test(
         feature = "sync",
-        async(
-            all(
-                not(any(feature = "sync", feature = "tokio-rustls-tls")),
-                feature = "with-tokio"
-            ),
-            tokio::test
-        ),
+        async(all(not(feature = "sync"), feature = "with-tokio"), tokio::test),
         async(
             all(not(feature = "sync"), feature = "with-async-std"),
             async_std::test

--- a/s3/src/bucket.rs
+++ b/s3/src/bucket.rs
@@ -2504,9 +2504,9 @@ mod test {
         // cleanup (and test Delete)
         let (_, code) = bucket.delete_object_blocking(&client, s3_path).unwrap();
         assert_eq!(code, 204);
-        let (_, code) = bucket.delete_object_blocking(s3_path_2).unwrap();
+        let (_, code) = bucket.delete_object_blocking(&client, s3_path_2).unwrap();
         assert_eq!(code, 204);
-        let (_, code) = bucket.delete_object_blocking(s3_path_3).unwrap();
+        let (_, code) = bucket.delete_object_blocking(&client, s3_path_3).unwrap();
         assert_eq!(code, 204);
     }
 

--- a/s3/src/client.rs
+++ b/s3/src/client.rs
@@ -7,19 +7,13 @@ pub trait Client<'a> {
 }
 
 #[cfg(feature = "with-attohttpc")]
-pub use self::attohttpc::AttoHttpClient;
-
-#[cfg(feature = "with-attohttpc")]
 mod attohttpc {
     use super::Client;
     use crate::blocking::AttoRequest;
     use crate::{bucket::Bucket, command::Command};
     use time::OffsetDateTime;
 
-    #[derive(Clone)]
-    pub struct AttoHttpClient;
-
-    impl<'a> Client<'a> for AttoHttpClient {
+    impl<'a> Client<'a> for attohttpc::Session {
         type Request = AttoRequest<'a>;
 
         fn request(
@@ -29,6 +23,7 @@ mod attohttpc {
             command: Command<'a>,
         ) -> Self::Request {
             AttoRequest {
+                session: self,
                 bucket,
                 path,
                 command,
@@ -44,7 +39,6 @@ mod surf {
     use super::Client;
     use crate::surf_request::SurfRequest;
     use crate::{bucket::Bucket, command::Command};
-    use std::borrow::Cow;
     use time::OffsetDateTime;
 
     impl<'a> Client<'a> for surf::Client {
@@ -57,7 +51,7 @@ mod surf {
             command: Command<'a>,
         ) -> Self::Request {
             SurfRequest {
-                client: Cow::Borrowed(self),
+                client: self,
                 bucket,
                 path,
                 command,
@@ -73,7 +67,6 @@ mod reqwest {
     use super::Client;
     use crate::request::Reqwest;
     use crate::{bucket::Bucket, command::Command};
-    use std::borrow::Cow;
     use time::OffsetDateTime;
 
     impl<'a> Client<'a> for reqwest::Client {
@@ -86,7 +79,7 @@ mod reqwest {
             command: Command<'a>,
         ) -> Self::Request {
             Reqwest {
-                client: Cow::Borrowed(self),
+                client: self,
                 bucket,
                 path,
                 command,

--- a/s3/src/client.rs
+++ b/s3/src/client.rs
@@ -1,0 +1,98 @@
+use crate::{bucket::Bucket, command::Command, request_trait::Request};
+
+pub trait Client<'a> {
+    type Request: Request + 'a;
+
+    fn request(&'a self, bucket: &'a Bucket, path: &'a str, command: Command<'a>) -> Self::Request;
+}
+
+#[cfg(feature = "with-attohttpc")]
+pub use self::attohttpc::AttoHttpClient;
+
+#[cfg(feature = "with-attohttpc")]
+mod attohttpc {
+    use super::Client;
+    use crate::blocking::AttoRequest;
+    use crate::{bucket::Bucket, command::Command};
+    use time::OffsetDateTime;
+
+    #[derive(Clone)]
+    pub struct AttoHttpClient;
+
+    impl<'a> Client<'a> for AttoHttpClient {
+        type Request = AttoRequest<'a>;
+
+        fn request(
+            &'a self,
+            bucket: &'a Bucket,
+            path: &'a str,
+            command: Command<'a>,
+        ) -> Self::Request {
+            AttoRequest {
+                bucket,
+                path,
+                command,
+                datetime: OffsetDateTime::now_utc(),
+                sync: true,
+            }
+        }
+    }
+}
+
+#[cfg(feature = "with-surf")]
+mod surf {
+    use super::Client;
+    use crate::surf_request::SurfRequest;
+    use crate::{bucket::Bucket, command::Command};
+    use std::borrow::Cow;
+    use time::OffsetDateTime;
+
+    impl<'a> Client<'a> for surf::Client {
+        type Request = SurfRequest<'a>;
+
+        fn request(
+            &'a self,
+            bucket: &'a Bucket,
+            path: &'a str,
+            command: Command<'a>,
+        ) -> Self::Request {
+            SurfRequest {
+                client: Cow::Borrowed(self),
+                bucket,
+                path,
+                command,
+                datetime: OffsetDateTime::now_utc(),
+                sync: false,
+            }
+        }
+    }
+}
+
+#[cfg(feature = "with-reqwest")]
+mod reqwest {
+    use super::Client;
+    use crate::request::Reqwest;
+    use crate::{bucket::Bucket, command::Command};
+    use std::borrow::Cow;
+    use time::OffsetDateTime;
+
+    impl<'a> Client<'a> for reqwest::Client {
+        type Request = Reqwest<'a>;
+
+        fn request(
+            &'a self,
+            bucket: &'a Bucket,
+            path: &'a str,
+            command: Command<'a>,
+        ) -> Self::Request {
+            Reqwest {
+                client: Cow::Borrowed(self),
+                bucket,
+                path,
+                command,
+                datetime: OffsetDateTime::now_utc(),
+                sync: false,
+            }
+        }
+    }
+}

--- a/s3/src/error.rs
+++ b/s3/src/error.rs
@@ -20,7 +20,7 @@ pub enum S3Error {
     UrlParse(#[from] url::ParseError),
     #[error("io: {0}")]
     Io(#[from] std::io::Error),
-    #[cfg(feature = "with-tokio")]
+    #[cfg(feature = "with-reqwest")]
     #[error("reqwest: {0}")]
     Reqwest(#[from] reqwest::Error),
     #[error("header to string: {0}")]
@@ -33,10 +33,10 @@ pub enum S3Error {
     InvalidHeaderValue(#[from] http::header::InvalidHeaderValue),
     #[error("invalid header name: {0}")]
     InvalidHeaderName(#[from] http::header::InvalidHeaderName),
-    #[cfg(feature = "with-async-std")]
+    #[cfg(feature = "with-surf")]
     #[error("surf: {0}")]
     Surf(String),
-    #[cfg(feature = "sync")]
+    #[cfg(feature = "with-attohttpc")]
     #[error("attohttpc: {0}")]
     Atto(#[from] attohttpc::Error),
 }

--- a/s3/src/lib.rs
+++ b/s3/src/lib.rs
@@ -12,17 +12,18 @@ pub use bucket::Tag;
 pub use bucket_ops::BucketConfiguration;
 pub use region::Region;
 
-#[cfg(feature = "sync")]
+#[cfg(feature = "with-attohttpc")]
 pub mod blocking;
 pub mod bucket;
 pub mod bucket_ops;
+pub mod client;
 pub mod command;
 pub mod deserializer;
-#[cfg(feature = "with-tokio")]
+#[cfg(feature = "with-reqwest")]
 pub mod request;
 pub mod serde_types;
 pub mod signing;
-#[cfg(feature = "with-async-std")]
+#[cfg(feature = "with-surf")]
 pub mod surf_request;
 
 pub mod error;

--- a/s3/src/request.rs
+++ b/s3/src/request.rs
@@ -1,6 +1,8 @@
 extern crate base64;
 extern crate md5;
 
+use std::borrow::Cow;
+
 use maybe_async::maybe_async;
 use reqwest::{Client, Response};
 use time::OffsetDateTime;
@@ -15,6 +17,7 @@ use tokio_stream::StreamExt;
 
 // Temporary structure for making a request
 pub struct Reqwest<'a> {
+    pub client: Cow<'a, reqwest::Client>,
     pub bucket: &'a Bucket,
     pub path: &'a str,
     pub command: Command<'a>,
@@ -50,31 +53,6 @@ impl<'a> Request for Reqwest<'a> {
             Err(e) => return Err(e),
         };
 
-        let mut client_builder = Client::builder();
-        if let Some(timeout) = self.bucket.request_timeout {
-            client_builder = client_builder.timeout(timeout)
-        }
-
-        if cfg!(feature = "no-verify-ssl") {
-            cfg_if::cfg_if! {
-                if #[cfg(feature = "tokio-native-tls")]
-                {
-                    client_builder = client_builder.danger_accept_invalid_hostnames(true);
-                }
-
-            }
-
-            cfg_if::cfg_if! {
-                if #[cfg(any(feature = "tokio-native-tls", feature = "tokio-rustls-tls"))]
-                {
-                    client_builder = client_builder.danger_accept_invalid_certs(true);
-                }
-
-            }
-        }
-
-        let client = client_builder.build().expect("Could not build client!");
-
         let method = match self.command.http_verb() {
             HttpMethod::Delete => reqwest::Method::DELETE,
             HttpMethod::Get => reqwest::Method::GET,
@@ -83,10 +61,18 @@ impl<'a> Request for Reqwest<'a> {
             HttpMethod::Head => reqwest::Method::HEAD,
         };
 
-        let request = client
+        let request = self
+            .client
             .request(method, self.url().as_str())
-            .headers(headers)
-            .body(self.request_body());
+            .headers(headers);
+
+        let request = if let Some(timeout) = self.bucket.request_timeout {
+            request.timeout(timeout)
+        } else {
+            request
+        };
+
+        let request = request.body(self.request_body());
 
         let response = request.send().await?;
 
@@ -143,12 +129,36 @@ impl<'a> Request for Reqwest<'a> {
 impl<'a> Reqwest<'a> {
     pub fn new<'b>(bucket: &'b Bucket, path: &'b str, command: Command<'b>) -> Reqwest<'b> {
         Reqwest {
+            client: Cow::Owned(Self::build_client()),
             bucket,
             path,
             command,
             datetime: OffsetDateTime::now_utc(),
             sync: false,
         }
+    }
+
+    fn build_client() -> reqwest::Client {
+        #[allow(unused_mut)]
+        let mut client_builder = Client::builder();
+
+        if cfg!(feature = "no-verify-ssl") {
+            cfg_if::cfg_if! {
+                if #[cfg(feature = "tokio-native-tls")]
+                {
+                    client_builder = client_builder.danger_accept_invalid_hostnames(true)
+                }
+            }
+
+            cfg_if::cfg_if! {
+                if #[cfg(any(feature = "tokio-native-tls", feature = "tokio-rustls-tls"))]
+                {
+                    client_builder = client_builder.danger_accept_invalid_certs(true);
+                }
+            }
+        }
+
+        client_builder.build().expect("Could not build client!")
     }
 }
 

--- a/s3/src/surf_request.rs
+++ b/s3/src/surf_request.rs
@@ -136,9 +136,9 @@ impl<'a> Request for SurfRequest<'a> {
 mod tests {
     use crate::bucket::Bucket;
     use crate::command::Command;
+    use crate::error::S3Error;
     use crate::request_trait::Request;
     use crate::surf_request::SurfRequest;
-    use crate::error::S3Error;
     use awscreds::Credentials;
     use time::OffsetDateTime;
 

--- a/s3/src/utils.rs
+++ b/s3/src/utils.rs
@@ -120,8 +120,8 @@ impl GetAndConvertHeaders for http::header::HeaderMap {
     }
 }
 
-impl From<&http::HeaderMap> for HeadObjectResult {
-    fn from(headers: &http::HeaderMap) -> Self {
+impl From<http::HeaderMap> for HeadObjectResult {
+    fn from(headers: http::HeaderMap) -> Self {
         let mut result = HeadObjectResult {
             accept_ranges: headers.get_string("accept-ranges"),
             cache_control: headers.get_string("Cache-Control"),

--- a/s3/src/utils.rs
+++ b/s3/src/utils.rs
@@ -16,9 +16,9 @@ use async_std::path::Path;
 use std::path::Path;
 
 #[cfg(feature = "with-async-std")]
-use futures_io::AsyncRead;
+use async_std::io::ReadExt;
 #[cfg(feature = "with-async-std")]
-use futures_util::AsyncReadExt;
+use futures_io::AsyncRead;
 #[cfg(feature = "sync")]
 use std::io::Read;
 #[cfg(feature = "with-tokio")]


### PR DESCRIPTION
This has a few benefits:
1. Consumers of this crate are now capable of bringing their own HTTP Clients (so long as they produce futures that are Send)
2. Consumers can enable runtime support (tokio v async-std v sync) without being forced into a specific Client choice
3. Clients are no longer constructed for each request and can be re-used for multiple requests, meaning we can make use of a client's built in connection pooling instead of building new clients per request

Drawbacks:
1. Every method on Bucket now expects a &Client argument. This could be worked around by storing the client inside a bucket, but I personally prefer to keep them separate