### PR TITLE
Import futures-* crates directly instead of through futures

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ while `tokio` methods are generic over `tokio::io::AsyncWriteExt`.
 
 #### PUT
 
-Each `GET` method has a `PUT` companion `sync` and `async` methods are generic over `std::io::Read`. `async` `stream` methods are generic over `futures::io::AsyncReadExt`, while `tokio` methods are generic over `tokio::io::AsyncReadExt`.
+Each `GET` method has a `PUT` companion `sync` and `async` methods are generic over `std::io::Read`. `async` `stream` methods are generic over `futures_io::AsyncReadExt`, while `tokio` methods are generic over `tokio::io::AsyncReadExt`.
 
 |         |                                                                                                                                 |
 |---------|---------------------------------------------------------------------------------------------------------------------------------|

--- a/s3/Cargo.toml
+++ b/s3/Cargo.toml
@@ -27,7 +27,8 @@ aws-region = "0.23"
 base64 = "0.13.0"
 cfg-if = "1"
 chrono = "0.4"
-futures = { version = "0.3", optional = true }
+futures-io = { version = "0.3", optional = true }
+futures-util = { version = "0.3", optional = true, features = ["io"] }
 hex = "0.4"
 hmac = "0.11"
 http = "0.2"
@@ -50,8 +51,8 @@ minidom = { version = "0.13", optional = true }
 block_on_proc = { version = "0.2", optional = true }
 
 [features]
-with-tokio = ["reqwest", "tokio", "futures", "tokio/fs"]
-with-async-std = ["async-std", "surf", "futures"]
+with-tokio = ["reqwest", "tokio", "tokio/fs"]
+with-async-std = ["async-std", "surf", "futures-io", "futures-util"]
 sync = ["attohttpc", "maybe-async/is_sync"]
 default = ["tags", "tokio-native-tls"]
 no-verify-ssl = []

--- a/s3/src/bucket.rs
+++ b/s3/src/bucket.rs
@@ -25,7 +25,7 @@ use crate::surf_request::SurfRequest as RequestImpl;
 // use tokio::fs::File;
 
 #[cfg(feature = "with-async-std")]
-use futures::io::{AsyncRead, AsyncWrite};
+use futures_io::{AsyncRead, AsyncWrite};
 #[cfg(feature = "with-tokio")]
 use tokio::io::{AsyncRead, AsyncWrite};
 
@@ -709,7 +709,7 @@ impl Bucket {
     /// #[cfg(feature = "with-async-std")]
     /// let mut path = async_std::fs::File::open(path).await?;
     /// // Async variant with `tokio` or `async-std` features
-    /// // Generic over futures::io::AsyncRead|tokio::io::AsyncRead + Unpin
+    /// // Generic over futures_io::AsyncRead|tokio::io::AsyncRead + Unpin
     /// let status_code = bucket.put_object_stream(&mut path, "/path").await?;
     ///
     /// // `sync` feature will produce an identical method

--- a/s3/src/request_trait.rs
+++ b/s3/src/request_trait.rs
@@ -27,7 +27,7 @@ pub trait Request {
         writer: &mut T,
     ) -> Result<u16>;
     #[cfg(feature = "with-async-std")]
-    async fn response_data_to_writer<T: futures::io::AsyncWrite + Send + Unpin>(
+    async fn response_data_to_writer<T: futures_io::AsyncWrite + Send + Unpin>(
         &self,
         writer: &mut T,
     ) -> Result<u16>;

--- a/s3/src/surf_request.rs
+++ b/s3/src/surf_request.rs
@@ -1,5 +1,5 @@
 use async_std::io::{ReadExt, WriteExt};
-use futures::io::AsyncWrite;
+use futures_io::AsyncWrite;
 
 use super::bucket::Bucket;
 use super::command::Command;

--- a/s3/src/utils.rs
+++ b/s3/src/utils.rs
@@ -16,7 +16,9 @@ use async_std::path::Path;
 use std::path::Path;
 
 #[cfg(feature = "with-async-std")]
-use futures::io::{AsyncRead, AsyncReadExt};
+use futures_io::AsyncRead;
+#[cfg(feature = "with-async-std")]
+use futures_util::AsyncReadExt;
 #[cfg(feature = "sync")]
 use std::io::Read;
 #[cfg(feature = "with-tokio")]


### PR DESCRIPTION
Was partially broken due to #230 introducing new imports from `futures`, and partially due to me missing that it should have been `futures_util` in one place instead in #227.