### PR TITLE
cargo: Move `tokio-stream` create behind the `with-tokio` feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ a `PUT` presigned URL, meaning they can upload to a specific key in S3 for the d
 
 #### Features
 
-There are a lot of various featuers that enable a wide variaty of use cases, refer to `s3/Cargo.toml` for an exhaustive list. Below is a table of various useful features as well as a short description for each.
+There are a lot of various features that enable a wide variety of use cases, refer to `s3/Cargo.toml` for an exhaustive list. Below is a table of various useful features as well as a short description for each.
 
 + `default` - `tokio` runtime and a `native-tls` implementation
 + `blocking` - generates `*_blocking` variant of all `Bucket` methods, otherwise only `async` versions are available

--- a/s3/Cargo.toml
+++ b/s3/Cargo.toml
@@ -44,14 +44,14 @@ sha2 = "0.9"
 anyhow = "1"
 surf = { version = "2", optional = true, default-features = false, features = ["h1-client-rustls"] }
 tokio = { version = "1", features = ["io-util"], optional = true, default-features = false }
-tokio-stream = "0.1"
+tokio-stream = { version = "0.1", optional = true }
 url = "2"
 minidom = { version = "0.13", optional = true }
 
 block_on_proc = { version = "0.2", optional = true }
 
 [features]
-with-tokio = ["reqwest", "tokio", "tokio/fs"]
+with-tokio = ["reqwest", "tokio", "tokio/fs", "tokio-stream"]
 with-async-std = ["async-std", "surf", "futures-io", "futures-util"]
 sync = ["attohttpc", "maybe-async/is_sync"]
 default = ["tags", "tokio-native-tls"]


### PR DESCRIPTION
`tokio-stream` has a dependency on `tokio` and is only used within the `request` module, which depends on the `with-tokio` feature.  As such, in order to completely prevent `tokio` from appearing in the crate graph, this crate must be marked optional and enabled when `with-tokio` is requested, omitted otherwise.

Also includes two drive-by typo-fixes in the features section of the readme.
