### PR TITLE
Allow access to credentials expiration

### DIFF
--- a/aws-creds/Cargo.toml
+++ b/aws-creds/Cargo.toml
@@ -23,7 +23,7 @@ url = "2"
 serde-xml-rs = "0.5"
 serde = "1"
 serde_derive = "1"
-
+time = { version = "0.3", features = ["serde"] }
 
 [features]
 default = ["native-tls"]

--- a/aws-creds/Cargo.toml
+++ b/aws-creds/Cargo.toml
@@ -23,7 +23,7 @@ url = "2"
 serde-xml-rs = "0.5"
 serde = "1"
 serde_derive = "1"
-time = { version = "0.3", features = ["serde"] }
+time = { version = "0.3", features = ["serde-well-known"] }
 
 [features]
 default = ["native-tls"]
@@ -33,3 +33,4 @@ rustls-tls = ["http-credentials", "attohttpc/tls-rustls"]
 
 [dev-dependencies]
 env_logger = "0.9"
+serde_json = "1"

--- a/aws-creds/src/credentials.rs
+++ b/aws-creds/src/credentials.rs
@@ -284,41 +284,33 @@ impl Credentials {
 
     #[cfg(feature = "http-credentials")]
     pub fn from_instance_metadata() -> Result<Credentials, CredentialsError> {
-        #[derive(Deserialize)]
-        #[serde(rename_all = "PascalCase")]
-        struct Response {
-            access_key_id: String,
-            secret_access_key: String,
-            token: String,
-            expiration: time::OffsetDateTime, // TODO fix #163
-        }
+        let resp: CredentialsFromInstanceMetadata =
+            match env::var("AWS_CONTAINER_CREDENTIALS_RELATIVE_URI") {
+                Ok(credentials_path) => {
+                    // We are on ECS
+                    attohttpc::get(&format!("http://169.254.170.2{}", credentials_path))
+                        .send()?
+                        .json()?
+                }
+                Err(_) => {
+                    if !is_ec2() {
+                        return Err(CredentialsError::NotEc2);
+                    }
 
-        let resp: Response = match env::var("AWS_CONTAINER_CREDENTIALS_RELATIVE_URI") {
-            Ok(credentials_path) => {
-                // We are on ECS
-                attohttpc::get(&format!("http://169.254.170.2{}", credentials_path))
+                    let role = attohttpc::get(
+                        "http://169.254.169.254/latest/meta-data/iam/security-credentials",
+                    )
+                    .send()?
+                    .text()?;
+
+                    attohttpc::get(&format!(
+                        "http://169.254.169.254/latest/meta-data/iam/security-credentials/{}",
+                        role
+                    ))
                     .send()?
                     .json()?
-            }
-            Err(_) => {
-                if !is_ec2() {
-                    return Err(CredentialsError::NotEc2);
                 }
-
-                let role = attohttpc::get(
-                    "http://169.254.169.254/latest/meta-data/iam/security-credentials",
-                )
-                .send()?
-                .text()?;
-
-                attohttpc::get(&format!(
-                    "http://169.254.169.254/latest/meta-data/iam/security-credentials/{}",
-                    role
-                ))
-                .send()?
-                .json()?
-            }
-        };
+            };
 
         Ok(Credentials {
             access_key: Some(resp.access_key_id),
@@ -375,4 +367,34 @@ fn is_ec2() -> bool {
         }
     }
     false
+}
+
+#[derive(Deserialize)]
+#[serde(rename_all = "PascalCase")]
+struct CredentialsFromInstanceMetadata {
+    access_key_id: String,
+    secret_access_key: String,
+    token: String,
+    #[serde(with = "time::serde::rfc3339")]
+    expiration: time::OffsetDateTime, // TODO fix #163
+}
+#[cfg(test)]
+#[test]
+fn test_instance_metadata_creds_deserialization() {
+    // As documented here:
+    // https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/iam-roles-for-amazon-ec2.html#instance-metadata-security-credentials
+    serde_json::from_str::<CredentialsFromInstanceMetadata>(
+        r#"
+        {
+            "Code" : "Success",
+            "LastUpdated" : "2012-04-26T16:39:16Z",
+            "Type" : "AWS-HMAC",
+            "AccessKeyId" : "ASIAIOSFODNN7EXAMPLE",
+            "SecretAccessKey" : "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY",
+            "Token" : "token",
+            "Expiration" : "2017-05-17T15:09:54Z"
+        }
+    "#,
+    )
+    .unwrap();
 }

--- a/aws-creds/src/lib.rs
+++ b/aws-creds/src/lib.rs
@@ -7,3 +7,6 @@ extern crate serde_derive;
 mod credentials;
 pub use credentials::*;
 pub mod error;
+
+// Reexport for e.g. users who need to build Credentials
+pub use time;


### PR DESCRIPTION
Following up on https://github.com/durch/rust-s3/issues/163#issuecomment-907420563.

This is a first step towards fixing #163, and it at least allows to work around it correctly.

Note: this is a breaking change for explicit constructions/destructurations of `Credentials`, so it will require a new major (`0.n+1`) version of aws-creds.