### PR TITLE
Remove never-encode-slash feature

### DIFF
--- a/s3/Cargo.toml
+++ b/s3/Cargo.toml
@@ -62,7 +62,6 @@ tokio-rustls-tls = ["with-tokio", "reqwest/rustls-tls", "aws-creds/rustls-tls"]
 sync-native-tls = ["sync", "aws-creds/native-tls", "attohttpc/tls"]
 sync-rustls-tls = ["sync", "aws-creds/rustls-tls", "attohttpc/tls-rustls"]
 blocking = ["block_on_proc", "tokio/rt", "tokio/rt-multi-thread"]
-never-encode-slash = []
 tags = ["minidom"]
 
 [dev-dependencies]

--- a/s3/src/request_trait.rs
+++ b/s3/src/request_trait.rs
@@ -197,8 +197,7 @@ pub trait Request {
         };
 
         url_str.push('/');
-
-        url_str.push_str(&signing::uri_encode(&path, true));
+        url_str.push_str(&signing::uri_encode(&path, false));
 
         // Append to url_path
         #[allow(clippy::collapsible_match)]

--- a/s3/src/signing.rs
+++ b/s3/src/signing.rs
@@ -57,18 +57,12 @@ pub const FRAGMENT: &AsciiSet = &CONTROLS
 pub const FRAGMENT_SLASH: &AsciiSet = &FRAGMENT.add(b'/');
 
 /// Encode a URI following the specific requirements of the AWS service.
-#[cfg(not(feature = "never-encode-slash"))]
 pub fn uri_encode(string: &str, encode_slash: bool) -> String {
     if encode_slash {
         utf8_percent_encode(string, FRAGMENT_SLASH).to_string()
     } else {
         utf8_percent_encode(string, FRAGMENT).to_string()
     }
-}
-
-#[cfg(feature = "never-encode-slash")]
-pub fn uri_encode(string: &str, encode_slash: bool) -> String {
-    utf8_percent_encode(string, FRAGMENT).to_string()
 }
 
 /// Generate a canonical URI string from the given URL.


### PR DESCRIPTION
and make the right behavior the default.

This was merged in #236, but never made it to a release and now it's gone again on `develop` too. I'm hoping that was just an accident.