### PR TITLE
aws-creds: Bump rust-ini to 0.18

### DIFF
--- a/aws-creds/Cargo.toml
+++ b/aws-creds/Cargo.toml
@@ -17,7 +17,7 @@ path = "src/lib.rs"
 [dependencies]
 anyhow = "1.0"
 dirs = "4"
-rust-ini = "0.17"
+rust-ini = "0.18"
 attohttpc = { version = "0.18", default-features = false, features = ["json"], optional = true }
 url = "2"
 serde-xml-rs = "0.5"


### PR DESCRIPTION
Bumping rust-ini gets rid of a duplicate ordered-multimap for us.
