### PR TITLE
Add custom_queries to command PresignGet

### DIFF
--- a/s3/bin/simple_crud.rs
+++ b/s3/bin/simple_crud.rs
@@ -90,7 +90,7 @@ pub fn main() -> Result<(), S3Error> {
         // Put a "test_file" with the contents of MESSAGE at the root of the
         // bucket.
         let (_, code) = bucket.put_object_blocking("test_file", MESSAGE.as_bytes())?;
-        // println!("{}", bucket.presign_get("test_file", 604801)?);
+        // println!("{}", bucket.presign_get("test_file", 604801, None)?);
         assert_eq!(200, code);
 
         // Get the "test_file" contents and make sure that the returned message

--- a/s3/src/command.rs
+++ b/s3/src/command.rs
@@ -1,3 +1,5 @@
+use std::collections::HashMap;
+
 use crate::serde_types::CompleteMultipartUploadData;
 
 use crate::EMPTY_PAYLOAD_SHA;
@@ -94,6 +96,7 @@ pub enum Command<'a> {
     GetBucketLocation,
     PresignGet {
         expiry_secs: u32,
+        custom_queries: Option<HashMap<String, String>>,
     },
     PresignPut {
         expiry_secs: u32,

--- a/s3/src/request_trait.rs
+++ b/s3/src/request_trait.rs
@@ -1,3 +1,4 @@
+use std::collections::HashMap;
 use hmac::Mac;
 use hmac::NewMac;
 use time::format_description::well_known::Rfc2822;
@@ -87,29 +88,17 @@ pub trait Request {
     }
 
     fn presigned(&self) -> Result<String> {
-        let expiry = match self.command() {
-            Command::PresignGet { expiry_secs } => expiry_secs,
-            Command::PresignPut { expiry_secs, .. } => expiry_secs,
-            Command::PresignDelete { expiry_secs } => expiry_secs,
+        let (expiry, custom_headers, custom_queries) = match self.command() {
+            Command::PresignGet { expiry_secs, custom_queries } => (expiry_secs, None, custom_queries),
+            Command::PresignPut { expiry_secs, custom_headers } => (expiry_secs, custom_headers, None),
+            Command::PresignDelete { expiry_secs } => (expiry_secs, None, None),
             _ => unreachable!(),
         };
 
-        #[allow(clippy::collapsible_match)]
-        if let Command::PresignPut { custom_headers, .. } = self.command() {
-            if let Some(custom_headers) = custom_headers {
-                let authorization = self.presigned_authorization(Some(&custom_headers))?;
-                return Ok(format!(
-                    "{}&X-Amz-Signature={}",
-                    self.presigned_url_no_sig(expiry, Some(&custom_headers))?,
-                    authorization
-                ));
-            }
-        }
-
         Ok(format!(
             "{}&X-Amz-Signature={}",
-            self.presigned_url_no_sig(expiry, None)?,
-            self.presigned_authorization(None)?
+            self.presigned_url_no_sig(expiry, custom_headers.as_ref(), custom_queries.as_ref())?,
+            self.presigned_authorization(custom_headers.as_ref())?
         ))
     }
 
@@ -133,34 +122,22 @@ pub trait Request {
     }
 
     fn presigned_canonical_request(&self, headers: &HeaderMap) -> Result<String> {
-        let expiry = match self.command() {
-            Command::PresignGet { expiry_secs } => expiry_secs,
-            Command::PresignPut { expiry_secs, .. } => expiry_secs,
-            Command::PresignDelete { expiry_secs } => expiry_secs,
+        let (expiry, custom_headers, custom_queries) = match self.command() {
+            Command::PresignGet { expiry_secs, custom_queries } => (expiry_secs, None, custom_queries),
+            Command::PresignPut { expiry_secs, custom_headers } => (expiry_secs, custom_headers, None),
+            Command::PresignDelete { expiry_secs } => (expiry_secs, None, None),
             _ => unreachable!(),
         };
 
-        #[allow(clippy::collapsible_match)]
-        if let Command::PresignPut { custom_headers, .. } = self.command() {
-            if let Some(custom_headers) = custom_headers {
-                return Ok(signing::canonical_request(
-                    &self.command().http_verb().to_string(),
-                    &self.presigned_url_no_sig(expiry, Some(&custom_headers))?,
-                    headers,
-                    "UNSIGNED-PAYLOAD",
-                ));
-            }
-        }
-
         Ok(signing::canonical_request(
             &self.command().http_verb().to_string(),
-            &self.presigned_url_no_sig(expiry, None)?,
+            &self.presigned_url_no_sig(expiry, custom_headers.as_ref(), custom_queries.as_ref())?,
             headers,
             "UNSIGNED-PAYLOAD",
         ))
     }
 
-    fn presigned_url_no_sig(&self, expiry: u32, custom_headers: Option<&HeaderMap>) -> Result<Url> {
+    fn presigned_url_no_sig(&self, expiry: u32, custom_headers: Option<&HeaderMap>, custom_queries: Option<&HashMap<String, String>>) -> Result<Url> {
         let bucket = self.bucket();
         let token = if let Some(security_token) = bucket.security_token() {
             Some(security_token)
@@ -168,7 +145,7 @@ pub trait Request {
             bucket.session_token()
         };
         let url = Url::parse(&format!(
-            "{}{}",
+            "{}{}{}",
             self.url(),
             &signing::authorization_query_params_no_sig(
                 &self.bucket().access_key().unwrap(),
@@ -177,7 +154,8 @@ pub trait Request {
                 expiry,
                 custom_headers,
                 token
-            )?
+            )?,
+            &signing::flatten_queries(custom_queries),
         ))?;
 
         Ok(url)


### PR DESCRIPTION
Added a field `custom_queries` to command `PresignGet`.

The motivation is to be able to set the `response-content-disposition` query parameter (causing the server to respond with the `Content-Disposition` header set to the specified value) to enable the browser to save the presigned url as a file using the specified file name.