### PR TITLE
Add support of Parallel GET/PUT for tokio

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,6 +79,7 @@ Each `GET` method has a `PUT` companion `sync` and `async` methods are generic o
 | `async/sync/async-blocking` | [put_object](https://docs.rs/rust-s3/latest/s3/bucket/struct.Bucket.html#method.put_object)                                     |
 | `async/sync/async-blocking` | [put_object_with_content_type](https://docs.rs/rust-s3/latest/s3/bucket/struct.Bucket.html#method.put_object_with_content_type) |
 | `async/sync/async-blocking` | [put_object_stream](https://docs.rs/rust-s3/latest/s3/bucket/struct.Bucket.html#method.put_object_stream)                       |
+| `async/sync/async-blocking` | [put_object_stream_parallel](https://docs.rs/rust-s3/latest/s3/bucket/struct.Bucket.html#method.put_object_stream_parallel)                       |
 
 #### List
 

--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ Each `GET` method has a `PUT` companion `sync` and `async` methods are generic o
 | `async/sync/async-blocking` | [put_object](https://docs.rs/rust-s3/latest/s3/bucket/struct.Bucket.html#method.put_object)                                     |
 | `async/sync/async-blocking` | [put_object_with_content_type](https://docs.rs/rust-s3/latest/s3/bucket/struct.Bucket.html#method.put_object_with_content_type) |
 | `async/sync/async-blocking` | [put_object_stream](https://docs.rs/rust-s3/latest/s3/bucket/struct.Bucket.html#method.put_object_stream)                       |
-| `async/sync/async-blocking` | [put_object_stream_parallel](https://docs.rs/rust-s3/latest/s3/bucket/struct.Bucket.html#method.put_object_stream_parallel)                       |
+| `async`                     | [put_object_stream_parallel](https://docs.rs/rust-s3/latest/s3/bucket/struct.Bucket.html#method.put_object_stream_parallel)     |
 
 #### List
 

--- a/s3/src/bucket.rs
+++ b/s3/src/bucket.rs
@@ -1317,7 +1317,9 @@ impl Bucket {
                 Some(chunk) => chunk,
                 None => Vec::with_capacity(CHUNK_SIZE),
             };
-            crate::utils::read_chunk(reader, &mut chunk).await?;
+            if part_number > 0 {
+                crate::utils::read_chunk(reader, &mut chunk).await?;
+            }
 
             part_number += 1;
 

--- a/s3/src/bucket.rs
+++ b/s3/src/bucket.rs
@@ -1313,14 +1313,11 @@ impl Bucket {
             }
 
             // Wait for loading chunk
-            let chunk = match chunks.pop() {
+            let mut chunk = match chunks.pop() {
                 Some(chunk) => chunk,
-                None => {
-                    let mut chunk = Vec::with_capacity(CHUNK_SIZE);
-                    crate::utils::read_chunk(reader, &mut chunk).await?;
-                    chunk
-                }
+                None => Vec::with_capacity(CHUNK_SIZE),
             };
+            crate::utils::read_chunk(reader, &mut chunk).await?;
 
             part_number += 1;
 

--- a/s3/src/error.rs
+++ b/s3/src/error.rs
@@ -23,6 +23,9 @@ pub enum S3Error {
     #[cfg(feature = "with-tokio")]
     #[error("reqwest: {0}")]
     Reqwest(#[from] reqwest::Error),
+    #[cfg(feature = "with-tokio")]
+    #[error("tokio sync: {0}")]
+    TokioSync(#[from] tokio::sync::mpsc::error::SendError<crate::serde_types::Part>),
     #[error("header to string: {0}")]
     HeaderToStr(#[from] http::header::ToStrError),
     #[error("from utf8: {0}")]

--- a/s3/src/error.rs
+++ b/s3/src/error.rs
@@ -23,9 +23,6 @@ pub enum S3Error {
     #[cfg(feature = "with-tokio")]
     #[error("reqwest: {0}")]
     Reqwest(#[from] reqwest::Error),
-    #[cfg(feature = "with-tokio")]
-    #[error("tokio sync: {0}")]
-    TokioSync(#[from] tokio::sync::mpsc::error::SendError<crate::serde_types::Part>),
     #[error("header to string: {0}")]
     HeaderToStr(#[from] http::header::ToStrError),
     #[error("from utf8: {0}")]

--- a/s3/src/serde_types.rs
+++ b/s3/src/serde_types.rs
@@ -226,7 +226,7 @@ pub struct HeadObjectResult {
     pub content_language: Option<String>,
     #[serde(rename = "ContentLength")]
     /// Size of the body in bytes.
-    pub content_length: Option<i64>,
+    pub content_length: Option<i128>,
     #[serde(rename = "ContentType")]
     /// A standard MIME type describing the format of the object data.
     pub content_type: Option<String>,


### PR DESCRIPTION
Hi, thanks for great works!

I found that `put_object_stream` command is using a **single thread**. It causes to diminish the performance abnormally for large file data transfer. It's even 2x+ slower than `put_object` command for 300MB+ files.

In my project, this performance degradation was a big stumbling block. So, I have added an additional command `put_object_stream_parallel` to perform this operation in parallel. This is an asynchronous method using `tokio` to help enable multi-part data transfer in parallel. The number of workers is set to 20, which is an empirical value for `rook-ceph` private storage cluster environment.

Besides, although unofficial, I also implemented multi-part downloads.

Since it's needed to go outside the thread boundary, my new implementation expects the `Bucket` to be wrapped in `Arc`.

## Performance Improvements

In the `rook-ceph` private storage cluster environment,

* GET (496MB): 3.125271375s => 2.366952567s [x1.37]
* PUT (496MB): 13.307903273s => 1.508496017s [x8.82]
