### PR TITLE
Allow setting the content type for multipart uploads

### DIFF
--- a/s3/src/command.rs
+++ b/s3/src/command.rs
@@ -105,7 +105,9 @@ pub enum Command<'a> {
     PresignDelete {
         expiry_secs: u32,
     },
-    InitiateMultipartUpload,
+    InitiateMultipartUpload {
+        content_type: &'a str,
+    },
     UploadPart {
         part_number: u32,
         content: &'a [u8],
@@ -147,7 +149,7 @@ impl<'a> Command<'a> {
             | Command::AbortMultipartUpload { .. }
             | Command::PresignDelete { .. }
             | Command::DeleteBucket => HttpMethod::Delete,
-            Command::InitiateMultipartUpload | Command::CompleteMultipartUpload { .. } => {
+            Command::InitiateMultipartUpload { .. } | Command::CompleteMultipartUpload { .. } => {
                 HttpMethod::Post
             }
             Command::HeadObject => HttpMethod::Head,
@@ -174,6 +176,7 @@ impl<'a> Command<'a> {
 
     pub fn content_type(&self) -> String {
         match self {
+            Command::InitiateMultipartUpload { content_type } => content_type.to_string(),
             Command::PutObject { content_type, .. } => content_type.to_string(),
             Command::CompleteMultipartUpload { .. } => "application/xml".into(),
             _ => "text/plain".into(),

--- a/s3/src/request_trait.rs
+++ b/s3/src/request_trait.rs
@@ -200,7 +200,7 @@ pub trait Request {
         // Append to url_path
         #[allow(clippy::collapsible_match)]
         match self.command() {
-            Command::InitiateMultipartUpload | Command::ListMultipartUploads { .. } => {
+            Command::InitiateMultipartUpload { .. } | Command::ListMultipartUploads { .. } => {
                 url_str.push_str("?uploads")
             }
             Command::AbortMultipartUpload { upload_id } => {


### PR DESCRIPTION
This is based on the patch from @chuigda, rebased onto master with
docs extended.

Fixes #172