### PR TITLE
Set the patch version of `time`

### DIFF
--- a/s3/Cargo.toml
+++ b/s3/Cargo.toml
@@ -28,7 +28,7 @@ aws-region = "0.24"
 # aws-region = {path = "../aws-region"}
 base64 = "0.13"
 cfg-if = "1"
-time = { version = "0.3", features = ["formatting", "macros"] }
+time = { version = "0.3.6", features = ["formatting", "macros"] }
 futures-io = { version = "0.3", optional = true }
 futures-util = { version = "0.3", optional = true, features = ["io"] }
 hex = "0.4"


### PR DESCRIPTION
The `time::format_description::well_known::Rfc2822` used in this crate
has been added since `time` version `0.3.6`. Therefore, Cargo.toml must set `0.3.6`.
