### PR TITLE
Allow turning ResponseData into Vec<u8> without reallocating

### DIFF
--- a/s3/src/request_trait.rs
+++ b/s3/src/request_trait.rs
@@ -32,6 +32,10 @@ impl ResponseData {
     pub fn status_code(&self) -> u16 {
         self.status_code
     }
+
+    pub fn into_bytes(self) -> Vec<u8> {
+        self.bytes
+    }
 }
 
 #[maybe_async::maybe_async]


### PR DESCRIPTION
Fix #280