### PR TITLE
Request streaming

### DIFF
--- a/s3/Cargo.toml
+++ b/s3/Cargo.toml
@@ -59,6 +59,8 @@ minidom = { version = "0.15", optional = true }
 
 block_on_proc = { version = "0.2", optional = true }
 
+bytes = "1.2.1"
+
 [features]
 with-tokio = ["reqwest", "tokio", "tokio/fs", "tokio-stream"]
 with-async-std = ["async-std", "surf", "futures-io", "futures-util"]

--- a/s3/Cargo.toml
+++ b/s3/Cargo.toml
@@ -59,11 +59,11 @@ minidom = { version = "0.15", optional = true }
 
 block_on_proc = { version = "0.2", optional = true }
 
-bytes = "1.2.1"
+bytes = { version = "1.2.1", optional = true }
 
 [features]
-with-tokio = ["reqwest", "tokio", "tokio/fs", "tokio-stream"]
-with-async-std = ["async-std", "surf", "futures-io", "futures-util"]
+with-tokio = ["reqwest", "tokio", "tokio/fs", "tokio-stream", "bytes"]
+with-async-std = ["async-std", "surf", "futures-io", "futures-util", "bytes"]
 sync = ["attohttpc", "maybe-async/is_sync"]
 default = ["tags", "tokio-native-tls", "fail-on-err"]
 no-verify-ssl = []

--- a/s3/src/bucket.rs
+++ b/s3/src/bucket.rs
@@ -39,6 +39,15 @@ use std::io::Read;
 // #[cfg(any(feature = "sync", feature = "with-tokio"))]
 // use std::path::Path;
 
+#[cfg(any(feature = "with-async-std", feature = "with-tokio"))]
+use bytes::Bytes;
+
+#[cfg(feature = "with-tokio")]
+use tokio_stream::Stream;
+
+#[cfg(feature = "with-async-std")]
+use futures_util::Stream;
+
 use crate::error::S3Error;
 use crate::request_trait::Request;
 use crate::serde_types::{
@@ -829,7 +838,7 @@ impl Bucket {
     pub async fn get_object_async_stream<S: AsRef<str>>(
         &self,
         path: S
-    ) -> Result<(<RequestImpl as Request>::ResponseStream, u16), S3Error> {
+    ) -> Result<(impl Stream<Item = Result<Bytes, S3Error>>, u16), S3Error> {
         let command = Command::GetObject;
         let request = RequestImpl::new(self, path.as_ref(), command);
         request.response_data_to_stream().await

--- a/s3/src/request.rs
+++ b/s3/src/request.rs
@@ -1,9 +1,13 @@
 extern crate base64;
 extern crate md5;
 
+use std::pin::Pin;
+use std::task::{Context, Poll};
+use bytes::Bytes;
 use maybe_async::maybe_async;
 use reqwest::{Client, Response};
 use time::OffsetDateTime;
+use tokio_stream::Stream;
 
 use crate::bucket::Bucket;
 use crate::command::Command;
@@ -26,6 +30,7 @@ pub struct Reqwest<'a> {
 impl<'a> Request for Reqwest<'a> {
     type Response = reqwest::Response;
     type HeaderMap = reqwest::header::HeaderMap;
+    type ResponseStream = GetObjectStream;
 
     fn command(&self) -> Command {
         self.command.clone()
@@ -137,6 +142,14 @@ impl<'a> Request for Reqwest<'a> {
         let headers = response.headers().clone();
         Ok((headers, status_code))
     }
+
+    async fn response_data_to_stream(&self) -> Result<(Self::ResponseStream, u16), S3Error> {
+        let response = self.response().await?;
+        let status_code = response.status();
+        let stream = response.bytes_stream();
+
+        Ok((GetObjectStream::new(stream), status_code.as_u16()))
+    }
 }
 
 impl<'a> Reqwest<'a> {
@@ -150,6 +163,36 @@ impl<'a> Reqwest<'a> {
         }
     }
 }
+
+pub struct GetObjectStream {
+    inner: Pin<Box<dyn Stream<Item=Result<Bytes, reqwest::Error>>>>,
+}
+
+impl GetObjectStream {
+    pub(crate) fn new<S: 'static>(stream: S) -> Self where S: Stream<Item=Result<Bytes, reqwest::Error>> {
+        Self {
+            inner: Box::pin(stream)
+        }
+    }
+}
+
+impl Stream for GetObjectStream {
+    type Item = Result<Bytes, S3Error>;
+
+    fn poll_next(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
+        match self.inner.as_mut().poll_next(cx) {
+            Poll::Ready(v) => {
+                Poll::Ready(v.map(|v| v.map_err(S3Error::from)))
+            }
+            Poll::Pending => Poll::Pending,
+        }
+    }
+
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        self.inner.size_hint()
+    }
+}
+
 
 #[cfg(test)]
 mod tests {

--- a/s3/src/request_trait.rs
+++ b/s3/src/request_trait.rs
@@ -14,6 +14,14 @@ use http::header::{
 };
 use http::HeaderMap;
 use std::fmt::Write as _;
+#[cfg(any(feature = "with-async-std", feature = "with-tokio"))]
+use bytes::Bytes;
+
+#[cfg(feature = "with-async-std")]
+use futures_util::Stream;
+
+#[cfg(feature = "with-tokio")]
+use tokio_stream::Stream;
 
 pub struct ResponseData {
     bytes: Vec<u8>,
@@ -47,7 +55,7 @@ pub trait Request {
     type HeaderMap;
 
     #[cfg(any(feature = "with-async-std", feature = "with-tokio"))]
-    type ResponseStream;
+    type ResponseStream: Stream<Item = Result<Bytes, S3Error>>;
 
     async fn response(&self) -> Result<Self::Response, S3Error>;
     async fn response_data(&self, etag: bool) -> Result<ResponseData, S3Error>;

--- a/s3/src/request_trait.rs
+++ b/s3/src/request_trait.rs
@@ -46,6 +46,9 @@ pub trait Request {
     type Response;
     type HeaderMap;
 
+    #[cfg(any(feature = "with-async-std", feature = "with-tokio"))]
+    type ResponseStream;
+
     async fn response(&self) -> Result<Self::Response, S3Error>;
     async fn response_data(&self, etag: bool) -> Result<ResponseData, S3Error>;
     #[cfg(feature = "with-tokio")]
@@ -63,6 +66,8 @@ pub trait Request {
         &self,
         writer: &mut T,
     ) -> Result<u16, S3Error>;
+    #[cfg(any(feature = "with-async-std", feature = "with-tokio"))]
+    async fn response_data_to_stream(&self) -> Result<(Self::ResponseStream, u16), S3Error>;
     async fn response_header(&self) -> Result<(Self::HeaderMap, u16), S3Error>;
     fn datetime(&self) -> OffsetDateTime;
     fn bucket(&self) -> Bucket;

--- a/s3/src/surf_request.rs
+++ b/s3/src/surf_request.rs
@@ -1,5 +1,9 @@
+use std::pin::Pin;
+use std::task::{Context, Poll};
 use async_std::io::{ReadExt, WriteExt};
-use futures_io::AsyncWrite;
+use bytes::Bytes;
+use futures_io::{AsyncRead, AsyncWrite};
+use futures_util::Stream;
 
 use super::bucket::Bucket;
 use super::command::Command;
@@ -27,6 +31,7 @@ pub struct SurfRequest<'a> {
 impl<'a> Request for SurfRequest<'a> {
     type Response = surf::Response;
     type HeaderMap = HeaderMap;
+    type ResponseStream = GetObjectStream;
 
     fn datetime(&self) -> OffsetDateTime {
         self.datetime
@@ -135,6 +140,16 @@ impl<'a> Request for SurfRequest<'a> {
         }
         Ok((header_map, status_code.into()))
     }
+
+    async fn response_data_to_stream(&self) -> Result<(Self::ResponseStream, u16), S3Error> {
+        let response = self.response().await?;
+        let length = response.len();
+        let status_code = response.status();
+
+        let stream = surf::http::Body::from_reader(response, None);
+
+        Ok((GetObjectStream::new(length, stream), status_code.into()))
+    }
 }
 
 impl<'a> SurfRequest<'a> {
@@ -146,6 +161,50 @@ impl<'a> SurfRequest<'a> {
             datetime: OffsetDateTime::now_utc(),
             sync: false,
         }
+    }
+}
+
+pub struct GetObjectStream {
+    length: Option<usize>,
+    inner: Pin<Box<dyn AsyncRead + Send>>,
+}
+
+impl GetObjectStream {
+    pub(crate) fn new<R: 'static>(
+        length: Option<usize>,
+        reader: R,
+    ) -> Self
+        where R: AsyncRead + Send
+    {
+        Self {
+            length,
+            inner: Box::pin(reader),
+        }
+    }
+}
+
+impl Stream for GetObjectStream {
+    type Item = Result<Bytes, S3Error>;
+
+    fn poll_next(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
+        let mut buffer = [0; 4096];
+
+        let read = match self.inner.as_mut().poll_read(cx, &mut buffer) {
+            Poll::Ready(Ok(s)) => s,
+            Poll::Ready(Err(err)) => return Poll::Ready(Some(Err(err.into()))),
+            Poll::Pending => return Poll::Pending,
+        };
+
+        if read == 0 {
+            return Poll::Ready(None);
+        }
+
+        let bytes = Bytes::copy_from_slice(&buffer[..read]);
+        Poll::Ready(Some(Ok(bytes)))
+    }
+
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        (0, self.length)
     }
 }
 


### PR DESCRIPTION
This is a partial implementation of #275, allowing the streaming of download requests using async `Stream<Item = Result<Bytes, S3Error>>` streams.

There is no equivalent version for synchronous rust.