### PR TITLE
Fix StsResponseCredentials deserialization

### DIFF
--- a/aws-creds/src/credentials.rs
+++ b/aws-creds/src/credentials.rs
@@ -96,6 +96,7 @@ pub struct AssumeRoleWithWebIdentityResult {
 pub struct StsResponseCredentials {
     pub session_token: String,
     pub secret_access_key: String,
+    #[serde(with = "time::serde::rfc3339")]
     pub expiration: time::OffsetDateTime,
     pub access_key_id: String,
 }


### PR DESCRIPTION
As documented here, this field is rfc3339 as well (and `time` by default has chosen a random non-standard format):
https://docs.aws.amazon.com/STS/latest/APIReference/API_AssumeRoleWithWebIdentity.html