### PR TITLE
Make put object stream proper async again

### DIFF
--- a/s3/src/bucket.rs
+++ b/s3/src/bucket.rs
@@ -32,6 +32,12 @@ use tokio::io::AsyncWrite;
 use crate::request::blocking::AttoRequest as RequestImpl;
 use std::io::Read;
 
+#[cfg(feature = "with-tokio")]
+use tokio::io::AsyncRead;
+
+#[cfg(feature = "with-async-std")]
+use futures::io::AsyncRead;
+
 use crate::error::S3Error;
 use crate::request::Request;
 use crate::serde_types::{
@@ -928,7 +934,7 @@ impl Bucket {
     /// # }
     /// ```
     #[maybe_async::async_impl]
-    pub async fn put_object_stream<R: Read + Unpin>(
+    pub async fn put_object_stream<R: AsyncRead + Unpin>(
         &self,
         reader: &mut R,
         s3_path: impl AsRef<str>,
@@ -999,7 +1005,7 @@ impl Bucket {
     /// # }
     /// ```
     #[maybe_async::async_impl]
-    pub async fn put_object_stream_with_content_type<R: Read + Unpin>(
+    pub async fn put_object_stream_with_content_type<R: AsyncRead + Unpin>(
         &self,
         reader: &mut R,
         s3_path: impl AsRef<str>,
@@ -1038,7 +1044,7 @@ impl Bucket {
     }
 
     #[maybe_async::async_impl]
-    async fn _put_object_stream_with_content_type<R: Read + Unpin>(
+    async fn _put_object_stream_with_content_type<R: AsyncRead + Unpin>(
         &self,
         reader: &mut R,
         s3_path: &str,
@@ -1046,7 +1052,7 @@ impl Bucket {
     ) -> Result<u16, S3Error> {
         // If the file is smaller CHUNK_SIZE, just do a regular upload.
         // Otherwise perform a multi-part upload.
-        let first_chunk = crate::utils::read_chunk(reader)?;
+        let first_chunk = crate::utils::read_chunk_async(reader).await?;
         if first_chunk.len() < CHUNK_SIZE {
             let response_data = self
                 .put_object_with_content_type(s3_path, first_chunk.as_slice(), content_type)
@@ -1072,7 +1078,7 @@ impl Bucket {
             let chunk = if part_number == 0 {
                 first_chunk.clone()
             } else {
-                crate::utils::read_chunk(reader)?
+                crate::utils::read_chunk_async(reader).await?
             };
 
             let done = chunk.len() < CHUNK_SIZE;
@@ -2495,8 +2501,18 @@ mod test {
         use async_std::stream::StreamExt;
         #[cfg(feature = "with-tokio")]
         use futures::StreamExt;
+        #[cfg(not(any(feature = "with-tokio", feature = "with-async-std")))]
         use std::fs::File;
+        #[cfg(feature = "with-tokio")]
+        use tokio::fs::File;
+        #[cfg(feature = "with-async-std")]
+        use async_std::fs::File;
+        #[cfg(not(any(feature = "with-tokio", feature = "with-async-std")))]
         use std::io::Write;
+        #[cfg(feature = "with-tokio")]
+        use tokio::io::AsyncWriteExt;
+        #[cfg(feature = "with-async-std")]
+        use async_std::io::WriteExt;
 
         init();
         let remote_path = "+stream_test_big";
@@ -2504,9 +2520,9 @@ mod test {
         std::fs::remove_file(remote_path).unwrap_or_else(|_| {});
         let content: Vec<u8> = object(20_000_000);
 
-        let mut file = File::create(local_path).unwrap();
-        file.write_all(&content).unwrap();
-        let mut reader = File::open(local_path).unwrap();
+        let mut file = File::create(local_path).await.unwrap();
+        file.write_all(&content).await.unwrap();
+        let mut reader = File::open(local_path).await.unwrap();
 
         let code = bucket
             .put_object_stream(&mut reader, remote_path)

--- a/s3/src/bucket.rs
+++ b/s3/src/bucket.rs
@@ -2498,21 +2498,21 @@ mod test {
     #[maybe_async::maybe_async]
     async fn streaming_test_put_get_delete_big_object(bucket: Bucket) {
         #[cfg(feature = "with-async-std")]
+        use async_std::fs::File;
+        #[cfg(feature = "with-async-std")]
+        use async_std::io::WriteExt;
+        #[cfg(feature = "with-async-std")]
         use async_std::stream::StreamExt;
         #[cfg(feature = "with-tokio")]
         use futures::StreamExt;
         #[cfg(not(any(feature = "with-tokio", feature = "with-async-std")))]
         use std::fs::File;
-        #[cfg(feature = "with-tokio")]
-        use tokio::fs::File;
-        #[cfg(feature = "with-async-std")]
-        use async_std::fs::File;
         #[cfg(not(any(feature = "with-tokio", feature = "with-async-std")))]
         use std::io::Write;
         #[cfg(feature = "with-tokio")]
+        use tokio::fs::File;
+        #[cfg(feature = "with-tokio")]
         use tokio::io::AsyncWriteExt;
-        #[cfg(feature = "with-async-std")]
-        use async_std::io::WriteExt;
 
         init();
         let remote_path = "+stream_test_big";


### PR DESCRIPTION
Partial fix for issues mentioned in https://github.com/durch/rust-s3/issues/305.

This should make uploading objects using streams properly async again.