### PR TITLE
fix: presigned custom header order

### DIFF
--- a/s3/src/bucket.rs
+++ b/s3/src/bucket.rs
@@ -2867,7 +2867,7 @@ mod test {
             .presign_put(s3_path, 86400, Some(custom_headers))
             .unwrap();
 
-        assert!(url.contains("host%3Bcustom_header"));
+        assert!(url.contains("custom_header%3Bhost"));
         assert!(url.contains("/test/test.file"))
     }
 

--- a/s3/src/signing.rs
+++ b/s3/src/signing.rs
@@ -221,6 +221,7 @@ pub fn authorization_query_params_no_sig(
         }
     }
 
+    signed_headers.sort();
     let signed_headers = signed_headers.join(";");
     let signed_headers = utf8_percent_encode(&signed_headers, FRAGMENT_SLASH);
 


### PR DESCRIPTION
According to https://docs.aws.amazon.com/general/latest/gr/sigv4-create-canonical-request.html, the header should be ordered to obtain a correct signature.