### PR TITLE
Migrate from serde-xml-rs to quick-xml

### DIFF
--- a/aws-creds/Cargo.toml
+++ b/aws-creds/Cargo.toml
@@ -22,7 +22,7 @@ attohttpc = { version = "0.22", default-features = false, features = [
     "json",
 ], optional = true }
 url = "2"
-serde-xml-rs = "0.5"
+quick-xml = { version = "0.26.0", features = [ "serialize" ] }
 serde = { version = "1", features = ["derive"] }
 time = { version = "^0.3.6", features = ["serde", "serde-well-known"] }
 log = "0.4"

--- a/aws-creds/src/credentials.rs
+++ b/aws-creds/src/credentials.rs
@@ -4,7 +4,6 @@ use crate::error::CredentialsError;
 use ini::Ini;
 use log::info;
 use serde::{Deserialize, Serialize};
-use serde_xml_rs as serde_xml;
 use std::collections::HashMap;
 use std::env;
 use std::ops::Deref;
@@ -226,8 +225,8 @@ impl Credentials {
         )?;
         let response = http_get(url.as_str())?;
         let serde_response =
-            serde_xml::from_str::<AssumeRoleWithWebIdentityResponse>(&response.text()?)?;
-        // assert!(serde_xml::from_str::<AssumeRoleWithWebIdentityResponse>(&response.text()?).unwrap());
+            quick_xml::de::from_str::<AssumeRoleWithWebIdentityResponse>(&response.text()?)?;
+        // assert!(quick_xml::de::from_str::<AssumeRoleWithWebIdentityResponse>(&response.text()?).unwrap());
 
         Ok(Credentials {
             access_key: Some(

--- a/aws-creds/src/error.rs
+++ b/aws-creds/src/error.rs
@@ -18,7 +18,7 @@ pub enum CredentialsError {
     #[error("ini: {0}")]
     Ini(#[from] ini::Error),
     #[error("serde_xml: {0}")]
-    SerdeXml(#[from] serde_xml_rs::Error),
+    SerdeXml(#[from] quick_xml::de::DeError),
     #[error("url parse: {0}")]
     UrlParse(#[from] url::ParseError),
     #[error("io: {0}")]

--- a/s3/Cargo.toml
+++ b/s3/Cargo.toml
@@ -67,7 +67,7 @@ reqwest = { version = "0.11", default-features = false, features = [
 ], optional = true }
 serde = "1"
 serde_derive = "1"
-serde-xml-rs = "0.5"
+quick-xml = { version = "0.26.0", features = [ "serialize" ] }
 sha2 = "0.10"
 thiserror = "1"
 surf = { version = "2", optional = true, default-features = false, features = [

--- a/s3/src/bucket.rs
+++ b/s3/src/bucket.rs
@@ -2,7 +2,6 @@
 use block_on_proc::block_on;
 #[cfg(feature = "tags")]
 use minidom::Element;
-use serde_xml_rs as serde_xml;
 use std::collections::HashMap;
 use std::time::Duration;
 
@@ -1204,7 +1203,8 @@ impl Bucket {
             return Err(error_from_response_data(response_data)?);
         }
 
-        let msg: InitiateMultipartUploadResponse = serde_xml::from_str(response_data.as_str()?)?;
+        let msg: InitiateMultipartUploadResponse =
+            quick_xml::de::from_str(response_data.as_str()?)?;
         Ok(msg)
     }
 
@@ -1221,7 +1221,8 @@ impl Bucket {
             return Err(error_from_response_data(response_data)?);
         }
 
-        let msg: InitiateMultipartUploadResponse = serde_xml::from_str(response_data.as_str()?)?;
+        let msg: InitiateMultipartUploadResponse =
+            quick_xml::de::from_str(response_data.as_str()?)?;
         Ok(msg)
     }
 
@@ -1388,7 +1389,7 @@ impl Bucket {
         let request = RequestImpl::new(self, "?location", Command::GetBucketLocation)?;
         let response_data = request.response_data(false).await?;
         let region_string = String::from_utf8_lossy(response_data.as_slice());
-        let region = match serde_xml::from_reader(region_string.as_bytes()) {
+        let region = match quick_xml::de::from_reader(region_string.as_bytes()) {
             Ok(r) => {
                 let location_result: BucketLocationResult = r;
                 location_result.region.parse()?
@@ -1806,7 +1807,7 @@ impl Bucket {
         };
         let request = RequestImpl::new(self, "/", command)?;
         let response_data = request.response_data(false).await?;
-        let list_bucket_result = serde_xml::from_reader(response_data.as_slice())?;
+        let list_bucket_result = quick_xml::de::from_reader(response_data.as_slice())?;
 
         Ok((list_bucket_result, response_data.status_code()))
     }
@@ -1889,7 +1890,7 @@ impl Bucket {
         };
         let request = RequestImpl::new(self, "/", command)?;
         let response_data = request.response_data(false).await?;
-        let list_bucket_result = serde_xml::from_reader(response_data.as_slice())?;
+        let list_bucket_result = quick_xml::de::from_reader(response_data.as_slice())?;
 
         Ok((list_bucket_result, response_data.status_code()))
     }

--- a/s3/src/error.rs
+++ b/s3/src/error.rs
@@ -28,7 +28,7 @@ pub enum S3Error {
     #[error("from utf8: {0}")]
     FromUtf8(#[from] std::string::FromUtf8Error),
     #[error("serde xml: {0}")]
-    SerdeXml(#[from] serde_xml_rs::Error),
+    SerdeXml(#[from] quick_xml::de::DeError),
     #[error("invalid header value: {0}")]
     InvalidHeaderValue(#[from] http::header::InvalidHeaderValue),
     #[error("invalid header name: {0}")]

--- a/s3/src/serde_types.rs
+++ b/s3/src/serde_types.rs
@@ -70,7 +70,7 @@ impl fmt::Display for CompleteMultipartUploadData {
         let mut parts = String::new();
         for part in self.parts.clone() {
             parts.push_str(
-                &serde_xml_rs::to_string(&part)
+                &quick_xml::se::to_string(&part)
                     .unwrap_or_else(|_| "Could not parse XML".to_string()),
             )
         }

--- a/s3/src/signing.rs
+++ b/s3/src/signing.rs
@@ -273,7 +273,6 @@ mod tests {
 
     use http::header::{HeaderName, HOST, RANGE};
     use http::HeaderMap;
-    use serde_xml_rs as serde_xml;
     use time::Date;
     use url::Url;
 
@@ -442,7 +441,7 @@ mod tests {
             </ListBucketResult>
         "###;
         let deserialized: ListBucketResult =
-            serde_xml::from_reader(result_string.as_bytes()).expect("Parse error!");
+            quick_xml::de::from_reader(result_string.as_bytes()).expect("Parse error!");
         assert!(deserialized.is_truncated);
     }
 


### PR DESCRIPTION
The xml-rs crate used by serde-xml-rs seems to be
unmaintained [1, 2] and has received an active RUSTSEC advisory [3] due to unfixed parsing issues [4].

Luckily, XML usage in the crates here is minimal
and can be one-to-one migrated to the recommended
quick-xml [5]. The download stats on crates.io show that quick-xml is currently being favoured.

[1] https://github.com/netvl/xml-rs/issues/219

[2] https://github.com/RReverser/serde-xml-rs/issues/180

[3] https://rustsec.org/advisories/RUSTSEC-2022-0048

[4] https://github.com/rustsec/advisory-db/issues/1121

[5] https://crates.io/crates/quick-xml