### PR TITLE
Change credential refresh log from info to debug

### DIFF
--- a/aws-creds/src/credentials.rs
+++ b/aws-creds/src/credentials.rs
@@ -2,7 +2,7 @@
 
 use crate::error::CredentialsError;
 use ini::Ini;
-use log::info;
+use log::debug;
 use serde::{Deserialize, Serialize};
 use serde_xml_rs as serde_xml;
 use std::collections::HashMap;
@@ -192,7 +192,7 @@ impl Credentials {
     pub fn refresh(&mut self) -> Result<(), CredentialsError> {
         if let Some(expiration) = self.expiration {
             if expiration.0 <= OffsetDateTime::now_utc() {
-                info!("Refreshing credentials!");
+                debug!("Refreshing credentials!");
                 let refreshed = Credentials::default()?;
                 *self = refreshed
             }


### PR DESCRIPTION
The new credentials refresh feature is extremely useful to our project - thank you! However, we're finding our logs have lots of noise with a refresh every 30 minutes. While we could change our RUST_LOG env var, I suspect it's more useful for the typical user for this log to be at the debug level.