### PR TITLE
Finish migrate from serde-xml-rs to quick-xml

### DIFF
--- a/aws-creds/Cargo.toml
+++ b/aws-creds/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "aws-creds"
-version = "0.34.0"
+version = "0.35.0"
 authors = ["Drazen Urch"]
 description = "Tiny Rust library for working with Amazon IAM credential,s, supports `s3` crate"
 repository = "https://github.com/durch/rust-s3"
@@ -18,11 +18,11 @@ path = "src/lib.rs"
 thiserror = "1"
 dirs = "4"
 rust-ini = "0.18"
-attohttpc = { version = "0.22", default-features = false, features = [
+attohttpc = { version = "0.24", default-features = false, features = [
     "json",
 ], optional = true }
 url = "2"
-quick-xml = { version = "0.26.0", features = [ "serialize" ] }
+quick-xml = { version = "0.27", features = [ "serialize" ] }
 serde = { version = "1", features = ["derive"] }
 time = { version = "^0.3.6", features = ["serde", "serde-well-known"] }
 log = "0.4"
@@ -35,5 +35,5 @@ native-tls-vendored = [ "http-credentials", "attohttpc/tls-vendored" ]
 rustls-tls = ["http-credentials", "attohttpc/tls-rustls"]
 
 [dev-dependencies]
-env_logger = "0.9"
+env_logger = "0.10"
 serde_json = "1"

--- a/aws-creds/src/credentials.rs
+++ b/aws-creds/src/credentials.rs
@@ -257,6 +257,7 @@ impl Credentials {
         })
     }
 
+    #[allow(clippy::should_implement_trait)]
     #[cfg(feature = "http-credentials")]
     pub fn default() -> Result<Credentials, CredentialsError> {
         Credentials::new(None, None, None, None, None)
@@ -333,7 +334,7 @@ impl Credentials {
             match env::var("AWS_CONTAINER_CREDENTIALS_RELATIVE_URI") {
                 Ok(credentials_path) => {
                     // We are on ECS
-                    attohttpc::get(&format!("http://169.254.170.2{}", credentials_path))
+                    attohttpc::get(format!("http://169.254.170.2{}", credentials_path))
                         .send()?
                         .json()?
                 }
@@ -348,7 +349,7 @@ impl Credentials {
                     .send()?
                     .text()?;
 
-                    attohttpc::get(&format!(
+                    attohttpc::get(format!(
                         "http://169.254.169.254/latest/meta-data/iam/security-credentials/{}",
                         role
                     ))
@@ -369,7 +370,7 @@ impl Credentials {
     pub fn from_profile(section: Option<&str>) -> Result<Credentials, CredentialsError> {
         let home_dir = dirs::home_dir().ok_or(CredentialsError::HomeDir)?;
         let profile = format!("{}/.aws/credentials", home_dir.display());
-        let conf = Ini::load_from_file(&profile)?;
+        let conf = Ini::load_from_file(profile)?;
         let section = section.unwrap_or("default");
         let data = conf
             .section(Some(section))


### PR DESCRIPTION
Bumps aws-creds version to 0.35 to force republishing.

Adds a  clippy `should_implement_trait` skip, as Credentials::default is implemented as a member function and not as an `impl` of `std::default::Default`.