### PR TITLE
Bump s3 deps to new aws-creds

### DIFF
--- a/aws-creds/Cargo.toml
+++ b/aws-creds/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "aws-creds"
-version = "0.34.0"
+version = "0.35.0"
 authors = ["Drazen Urch"]
 description = "Tiny Rust library for working with Amazon IAM credential,s, supports `s3` crate"
 repository = "https://github.com/durch/rust-s3"
@@ -18,11 +18,11 @@ path = "src/lib.rs"
 thiserror = "1"
 dirs = "4"
 rust-ini = "0.18"
-attohttpc = { version = "0.22", default-features = false, features = [
+attohttpc = { version = "0.24", default-features = false, features = [
     "json",
 ], optional = true }
 url = "2"
-quick-xml = { version = "0.26.0", features = [ "serialize" ] }
+quick-xml = { version = "0.27", features = [ "serialize" ] }
 serde = { version = "1", features = ["derive"] }
 time = { version = "^0.3.6", features = ["serde", "serde-well-known"] }
 log = "0.4"
@@ -35,5 +35,5 @@ native-tls-vendored = [ "http-credentials", "attohttpc/tls-vendored" ]
 rustls-tls = ["http-credentials", "attohttpc/tls-rustls"]
 
 [dev-dependencies]
-env_logger = "0.9"
+env_logger = "0.10"
 serde_json = "1"

--- a/aws-creds/src/credentials.rs
+++ b/aws-creds/src/credentials.rs
@@ -257,6 +257,7 @@ impl Credentials {
         })
     }
 
+    #[allow(clippy::should_implement_trait)]
     #[cfg(feature = "http-credentials")]
     pub fn default() -> Result<Credentials, CredentialsError> {
         Credentials::new(None, None, None, None, None)
@@ -333,7 +334,7 @@ impl Credentials {
             match env::var("AWS_CONTAINER_CREDENTIALS_RELATIVE_URI") {
                 Ok(credentials_path) => {
                     // We are on ECS
-                    attohttpc::get(&format!("http://169.254.170.2{}", credentials_path))
+                    attohttpc::get(format!("http://169.254.170.2{}", credentials_path))
                         .send()?
                         .json()?
                 }
@@ -348,7 +349,7 @@ impl Credentials {
                     .send()?
                     .text()?;
 
-                    attohttpc::get(&format!(
+                    attohttpc::get(format!(
                         "http://169.254.169.254/latest/meta-data/iam/security-credentials/{}",
                         role
                     ))
@@ -369,7 +370,7 @@ impl Credentials {
     pub fn from_profile(section: Option<&str>) -> Result<Credentials, CredentialsError> {
         let home_dir = dirs::home_dir().ok_or(CredentialsError::HomeDir)?;
         let profile = format!("{}/.aws/credentials", home_dir.display());
-        let conf = Ini::load_from_file(&profile)?;
+        let conf = Ini::load_from_file(profile)?;
         let section = section.unwrap_or("default");
         let data = conf
             .section(Some(section))

--- a/s3/Cargo.toml
+++ b/s3/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rust-s3"
-version = "0.33.0-beta5"
+version = "0.33.0-beta6"
 authors = ["Drazen Urch"]
 description = "Rust library for working with AWS S3 and compatible object storage APIs"
 repository = "https://github.com/durch/rust-s3"
@@ -43,12 +43,12 @@ path = "../examples/gcs-tokio.rs"
 [dependencies]
 async-std = { version = "1", optional = true }
 async-trait = "0.1"
-attohttpc = { version = "0.22", optional = true, default-features = false }
-aws-creds = { version = "0.34.0", default-features = false }
+attohttpc = { version = "0.24", optional = true, default-features = false }
+aws-creds = { version = "0.35.0", default-features = false }
 # aws-creds = { path = "../aws-creds", default-features = false }
 aws-region = "0.25.1"
 # aws-region = {path = "../aws-region"}
-base64 = "0.13"
+base64 = "0.21"
 cfg-if = "1"
 time = { version = "^0.3.6", features = ["formatting", "macros"] }
 futures = { version = "0.3", optional = true }
@@ -67,7 +67,7 @@ reqwest = { version = "0.11", default-features = false, features = [
 ], optional = true }
 serde = "1"
 serde_derive = "1"
-quick-xml = { version = "0.26.0", features = [ "serialize" ] }
+quick-xml = { version = "0.27", features = [ "serialize" ] }
 sha2 = "0.10"
 thiserror = "1"
 surf = { version = "2", optional = true, default-features = false, features = [
@@ -102,5 +102,5 @@ tags = ["minidom"]
 tokio = { version = "1", features = ["rt", "rt-multi-thread", "macros", "fs"] }
 async-std = { version = "1", features = ["attributes"] }
 uuid = { version = "1", features = ["v4"] }
-env_logger = "0.9"
+env_logger = "0.10"
 anyhow = "1"

--- a/s3/src/request/request_trait.rs
+++ b/s3/src/request/request_trait.rs
@@ -11,6 +11,7 @@ use crate::command::Command;
 use crate::error::S3Error;
 use crate::signing;
 use crate::LONG_DATETIME;
+use base64::engine::{general_purpose::STANDARD, Engine};
 use bytes::Bytes;
 use http::header::{
     HeaderName, ACCEPT, AUTHORIZATION, CONTENT_LENGTH, CONTENT_TYPE, DATE, HOST, RANGE,
@@ -477,15 +478,15 @@ pub trait Request {
 
         if let Command::PutObjectTagging { tags } = self.command() {
             let digest = md5::compute(tags);
-            let hash = base64::encode(digest.as_ref());
+            let hash = STANDARD.encode(digest.as_ref());
             headers.insert(HeaderName::from_static("content-md5"), hash.parse()?);
         } else if let Command::PutObject { content, .. } = self.command() {
             let digest = md5::compute(content);
-            let hash = base64::encode(digest.as_ref());
+            let hash = STANDARD.encode(digest.as_ref());
             headers.insert(HeaderName::from_static("content-md5"), hash.parse()?);
         } else if let Command::UploadPart { content, .. } = self.command() {
             let digest = md5::compute(content);
-            let hash = base64::encode(digest.as_ref());
+            let hash = STANDARD.encode(digest.as_ref());
             headers.insert(HeaderName::from_static("content-md5"), hash.parse()?);
         } else if let Command::GetObject {} = self.command() {
             headers.insert(ACCEPT, "application/octet-stream".to_string().parse()?);


### PR DESCRIPTION
This PR bumps the s3 crate dependencies to the new proposed aws-creds version. It depends on #326 and will not build until that PR is merged and the new version of aws-creds is available on the remote repository.

Also changes the base64 encode due to a deprecation in the base64 crate.