### PR TITLE
Update base64 dependency to 0.21 plus minor refactoring

### DIFF
--- a/s3/Cargo.toml
+++ b/s3/Cargo.toml
@@ -48,7 +48,7 @@ aws-creds = { version = "0.34.0", default-features = false }
 # aws-creds = { path = "../aws-creds", default-features = false }
 aws-region = "0.25.1"
 # aws-region = {path = "../aws-region"}
-base64 = "0.13"
+base64 = "0.21"
 cfg-if = "1"
 time = { version = "^0.3.6", features = ["formatting", "macros"] }
 futures = { version = "0.3", optional = true }


### PR DESCRIPTION
Update base64 dependency to the latest 0.21 version and while doing
that refactor some of the code where base64 is used.  The refactoring
has a few benefits:
- base64 encoding is now done into an on-stack buffer avoiding String
  heap allocation,
- Inserting Content-MD5 is now in a helper function avoiding code
  duplication,
- match is used rather than if-else-if chain so that self.command() is
  now called only once and
- there are now fewer ‘to_string’ calls reducing allocations.
