### PR TITLE
Minor compilation fixes

### DIFF
--- a/aws-creds/src/credentials.rs
+++ b/aws-creds/src/credentials.rs
@@ -188,6 +188,7 @@ fn http_get(url: &str) -> attohttpc::Result<attohttpc::Response> {
 }
 
 impl Credentials {
+    #[cfg(feature = "http-credentials")]
     pub fn refresh(&mut self) -> Result<(), CredentialsError> {
         if let Some(expiration) = self.expiration {
             if expiration.0 <= OffsetDateTime::now_utc() {
@@ -423,7 +424,6 @@ struct CredentialsFromInstanceMetadata {
     expiration: Rfc3339OffsetDateTime, // TODO fix #163
 }
 
-#[cfg(test)]
 #[test]
 fn test_instance_metadata_creds_deserialization() {
     // As documented here:
@@ -444,7 +444,7 @@ fn test_instance_metadata_creds_deserialization() {
     .unwrap();
 }
 
-#[cfg(test)]
+#[cfg(feature = "http-credentials")]
 #[ignore]
 #[test]
 fn test_credentials_refresh() {

--- a/examples/sync-backend.rs
+++ b/examples/sync-backend.rs
@@ -1,16 +1,12 @@
 // cargo run --example sync --no-default-features --features sync-native-tls
 
-use awscreds::Credentials;
-use s3::error::S3Error;
-use s3::Bucket;
-
 #[cfg(feature = "sync")]
-fn main() -> Result<(), S3Error> {
-    let bucket = Bucket::new(
+fn main() -> Result<(), s3::error::S3Error> {
+    let bucket = s3::Bucket::new(
         "rust-s3-test",
         "eu-central-1".parse()?,
         // Credentials are collected from environment, config, profile or instance metadata
-        Credentials::default()?,
+        awscreds::Credentials::default()?,
     )?;
 
     let s3_path = "test.file";

--- a/s3/src/bucket.rs
+++ b/s3/src/bucket.rs
@@ -2262,6 +2262,7 @@ mod test {
         Credentials::new(Some("test"), Some("test1234"), None, None, None).unwrap()
     }
 
+    #[allow(dead_code)]
     fn test_digital_ocean_credentials() -> Credentials {
         Credentials::new(
             Some(&env::var("DIGITAL_OCEAN_ACCESS_KEY_ID").unwrap()),
@@ -2329,6 +2330,7 @@ mod test {
         .with_path_style()
     }
 
+    #[allow(dead_code)]
     fn test_digital_ocean_bucket() -> Bucket {
         Bucket::new("rust-s3", Region::DoFra1, test_digital_ocean_credentials()).unwrap()
     }


### PR DESCRIPTION
Firstly, observe that aws-creds doesn’t compile without default
features enabled.  This is because Credentials::refresh method which
calls Credentials::default which is only defined if http-credentials
feature is enabled.  Change the code (and related tests) so that the
former method is present only if that feature is enabled.

Note that even with that, rust-s3 doesn’t compile without default
features enabled.  This is because rust-s3 depends on aws-creds with
the above bug present.  This will be fixed once the dependency is
updated.

Secondly, fix minor compilation warnings caused by conditional
compilation leading to some dead code.
