### PR TITLE
Add support for StreamReader

### DIFF
--- a/s3/src/error.rs
+++ b/s3/src/error.rs
@@ -51,6 +51,9 @@ pub enum S3Error {
 
 impl From<S3Error> for std::io::Error {
     fn from(item: S3Error) -> Self {
-        std::io::Error::new(std::io::ErrorKind::Other, item)
+        match item {
+            S3Error::Io(e) => e,
+            e => std::io::Error::new(std::io::ErrorKind::Other, e)     
+        }
     }
 }

--- a/s3/src/error.rs
+++ b/s3/src/error.rs
@@ -48,3 +48,9 @@ pub enum S3Error {
     #[error("fmt error: {0}")]
     FmtError(#[from] std::fmt::Error),
 }
+
+impl From<S3Error> for std::io::Error {
+    fn from(item: S3Error) -> Self {
+        std::io::Error::new(std::io::ErrorKind::Other, item)
+    }
+}

--- a/s3/src/request/request_trait.rs
+++ b/s3/src/request/request_trait.rs
@@ -31,7 +31,8 @@ pub struct ResponseData {
     headers: HashMap<String, String>,
 }
 
-type  DataStream = Pin<Box<dyn Stream<Item = Result<Bytes, S3Error>> + Send>>;
+pub type StreamItem = Result<Bytes, S3Error>;
+pub type DataStream = Pin<Box<dyn Stream<Item = StreamItem> + Send>>;
 
 #[cfg(any(feature = "with-tokio", feature = "with-async-std"))]
 pub struct ResponseDataStream {

--- a/s3/src/request/request_trait.rs
+++ b/s3/src/request/request_trait.rs
@@ -25,7 +25,6 @@ use futures_util::Stream;
 use tokio_stream::Stream;
 
 #[derive(Debug)]
-
 pub struct ResponseData {
     bytes: Bytes,
     status_code: u16,
@@ -38,6 +37,20 @@ type  DataStream = Pin<Box<dyn Stream<Item = Result<Bytes, S3Error>> + Send>>;
 pub struct ResponseDataStream {
     pub bytes: DataStream,
     pub status_code: u16,
+    pub headers: HashMap<String, String>,
+}
+
+pub fn raw_headers(map: &HeaderMap) -> HashMap<String, String> {
+    map.iter()
+        .map(|(k, v)| {
+            (
+                k.to_string(),
+                v.to_str()
+                    .unwrap_or("could-not-decode-header-value")
+                    .to_string(),
+            )
+        })
+        .collect::<HashMap<String, String>>()
 }
 
 #[cfg(any(feature = "with-tokio", feature = "with-async-std"))]
@@ -523,3 +536,5 @@ pub trait Request {
         Ok(headers)
     }
 }
+
+

--- a/s3/src/request/request_trait.rs
+++ b/s3/src/request/request_trait.rs
@@ -32,15 +32,17 @@ pub struct ResponseData {
     headers: HashMap<String, String>,
 }
 
+type  DataStream = Pin<Box<dyn Stream<Item = Result<Bytes, S3Error>> + Send>>;
+
 #[cfg(any(feature = "with-tokio", feature = "with-async-std"))]
 pub struct ResponseDataStream {
-    pub bytes: Pin<Box<dyn Stream<Item = Bytes>>>,
+    pub bytes: DataStream,
     pub status_code: u16,
 }
 
 #[cfg(any(feature = "with-tokio", feature = "with-async-std"))]
 impl ResponseDataStream {
-    pub fn bytes(&mut self) -> &mut Pin<Box<dyn Stream<Item = Bytes>>> {
+    pub fn bytes(&mut self) -> &mut DataStream {
         &mut self.bytes
     }
 }

--- a/s3/src/request/tokio_backend.rs
+++ b/s3/src/request/tokio_backend.rs
@@ -2,6 +2,7 @@ extern crate base64;
 extern crate md5;
 
 use bytes::Bytes;
+use futures::TryStreamExt;
 use maybe_async::maybe_async;
 use reqwest::{Client, Response};
 use std::collections::HashMap;
@@ -156,7 +157,8 @@ impl<'a> Request for Reqwest<'a> {
     async fn response_data_to_stream(&self) -> Result<ResponseDataStream, S3Error> {
         let response = self.response().await?;
         let status_code = response.status();
-        let stream = response.bytes_stream().filter_map(|b| b.ok());
+        let stream = response.bytes_stream()
+            .map_err(| e | S3Error::Reqwest(e));
 
         Ok(ResponseDataStream {
             bytes: Box::pin(stream),


### PR DESCRIPTION
Add support for [tokio_util](https://docs.rs/tokio-util/0.7.7/tokio_util/index.html)::[io](https://docs.rs/tokio-util/0.7.7/tokio_util/io/index.html)::[StreamReader](https://docs.rs/tokio-util/0.7.7/tokio_util/io/struct.StreamReader.html#) in ResponseDataStream.bytes 