### PR TITLE
feat: re-expose 'http-credentials' from 's3'

### DIFF
--- a/s3/Cargo.toml
+++ b/s3/Cargo.toml
@@ -100,6 +100,7 @@ with-tokio = [
     "futures",
 ]
 async-std-native-tls = ["with-async-std", "aws-creds/native-tls"]
+http-credentials = ["aws-creds/http-credentials"]
 with-async-std = ["async-std", "surf", "futures-io", "futures-util", "futures"]
 sync = ["attohttpc", "maybe-async/is_sync"]
 no-verify-ssl = []


### PR DESCRIPTION
`aws-creds` is re-exposed from `s3`. This means, technically, we don't need to depend on `aws-creds` when we already depend on `s3`. However, if we need the `http-credentials` from `aws-creds`, then we do need to depend on both which can create problems:
- `aws-creds` gets updated, but `s3` didn't yet get updated with the new version of `aws-creds`
- our code uses `Credential` from the new version of `aws-creds` and try to use it with `s3` which depends on the old version of `aws-creds`
- you get an error

That's usually the reason for re-exposing `aws-creds` from `s3` (to avoid this different versions of the same crate in the dependency tree). But today, there is no way to have `http-credentials` without importing both. This PR should solve that.