### PR TITLE
Fix Bytes version requirement

### DIFF
--- a/s3/Cargo.toml
+++ b/s3/Cargo.toml
@@ -83,7 +83,7 @@ native-tls = { version = "0.2", optional = true }
 tokio-stream = { version = "0.1", optional = true }
 url = "2"
 minidom = { version = "0.15", optional = true }
-bytes = { version = "1" }
+bytes = { version = "1.2" }
 block_on_proc = { version = "0.2", optional = true }
 
 [features]


### PR DESCRIPTION
0.34.0-rc4 doesn't compile with a version lower than this due to the absence of `impl From<Bytes> for Vec<u8>`.

The way to ensure this does not happen anymore is to have a CI run with [cargo-minimal-versions](https://crates.io/crates/cargo-minimal-versions).