### PR TITLE
fix: rustls causing openssl to be built

### DIFF
--- a/s3/Cargo.toml
+++ b/s3/Cargo.toml
@@ -43,10 +43,8 @@ path = "../examples/gcs-tokio.rs"
 async-std = { version = "1", optional = true }
 async-trait = "0.1"
 attohttpc = { version = "0.26", optional = true, default-features = false }
-aws-creds = { version = "0.36", default-features = false }
-# aws-creds = { path = "../aws-creds", default-features = false }
-aws-region = "0.25.4"
-# aws-region = {path = "../aws-region"}
+aws-creds = { version = "0.36", path = "../aws-creds", default-features = false }
+aws-region = { version = "0.25.4", path = "../aws-region" }
 base64 = "0.21"
 cfg-if = "1"
 time = { version = "^0.3.6", features = ["formatting", "macros"] }
@@ -60,8 +58,13 @@ hyper = { version = "0.14", default-features = false, features = [
     "client",
     "http1",
     "stream",
+    "tcp",
 ], optional = true }
 hyper-tls = { version = "0.5.0", default-features = false, optional = true }
+hyper-rustls = { version = "0.24", default-features = false, optional = true }
+rustls = { version = "0.21", optional = true }
+tokio-rustls = { version = "0.24.1", optional = true }
+rustls-native-certs = { version = "0.6.3", optional = true }
 log = "0.4"
 maybe-async = { version = "0.2" }
 md5 = "0.7"
@@ -88,15 +91,12 @@ block_on_proc = { version = "0.2", optional = true }
 
 [features]
 default = ["tags", "use-tokio-native-tls", "fail-on-err"]
-use-tokio-native-tls = ["with-tokio", "aws-creds/native-tls"]
+use-tokio-native-tls = ["with-tokio", "aws-creds/native-tls", "tokio-native-tls", "hyper-tls", "native-tls"]
 with-tokio = [
     "hyper",
-    "hyper-tls",
     "tokio",
     "tokio/fs",
     "tokio-stream",
-    "tokio-native-tls",
-    "native-tls",
     "futures",
 ]
 async-std-native-tls = ["with-async-std", "aws-creds/native-tls"]
@@ -105,7 +105,7 @@ with-async-std = ["async-std", "surf", "futures-io", "futures-util", "futures"]
 sync = ["attohttpc", "maybe-async/is_sync"]
 no-verify-ssl = []
 fail-on-err = []
-tokio-rustls-tls = ["with-tokio", "aws-creds/rustls-tls"]
+tokio-rustls-tls = ["with-tokio", "aws-creds/rustls-tls", "tokio-rustls", "hyper-rustls", "rustls", "rustls-native-certs"]
 sync-native-tls = ["sync", "aws-creds/native-tls", "attohttpc/tls"]
 sync-native-tls-vendored = [
     "sync",

--- a/s3/src/bucket.rs
+++ b/s3/src/bucket.rs
@@ -10,7 +10,7 @@ use crate::command::{Command, Multipart};
 use crate::creds::Credentials;
 use crate::region::Region;
 #[cfg(feature = "with-tokio")]
-use crate::request::tokio_backend::client;
+use crate::request::tokio_backend::{client, HttpsConnector};
 use crate::request::ResponseData;
 #[cfg(any(feature = "with-tokio", feature = "with-async-std"))]
 use crate::request::ResponseDataStream;
@@ -106,7 +106,7 @@ pub struct Bucket {
     path_style: bool,
     listobjects_v2: bool,
     #[cfg(feature = "with-tokio")]
-    http_client: Arc<hyper::Client<hyper_tls::HttpsConnector<hyper::client::HttpConnector>>>,
+    http_client: Arc<hyper::Client<HttpsConnector<hyper::client::HttpConnector>>>,
 }
 
 impl Bucket {
@@ -124,9 +124,7 @@ impl Bucket {
     }
 
     #[cfg(feature = "with-tokio")]
-    pub fn http_client(
-        &self,
-    ) -> Arc<hyper::Client<hyper_tls::HttpsConnector<hyper::client::HttpConnector>>> {
+    pub fn http_client(&self) -> Arc<hyper::Client<HttpsConnector<hyper::client::HttpConnector>>> {
         Arc::clone(&self.http_client)
     }
 }

--- a/s3/src/error.rs
+++ b/s3/src/error.rs
@@ -27,9 +27,12 @@ pub enum S3Error {
     #[cfg(feature = "with-tokio")]
     #[error("hyper: {0}")]
     Hyper(#[from] hyper::Error),
-    #[cfg(feature = "with-tokio")]
+    #[cfg(feature = "use-tokio-native-tls")]
     #[error("native-tls: {0}")]
     NativeTls(#[from] native_tls::Error),
+    #[cfg(feature = "with-tokio-rustls")]
+    #[error("rustls: {0}")]
+    Rustls(#[from] rustls::TLSError),
     #[error("header to string: {0}")]
     HeaderToStr(#[from] http::header::ToStrError),
     #[error("from utf8: {0}")]


### PR DESCRIPTION
This commit fixes rustls feature being dependant on native-tls and binding to libcrypto.

fixes: #369