### PR TITLE
Make Read and Write generics friendlier to dynamic dispatch

### DIFF
--- a/s3/src/bucket.rs
+++ b/s3/src/bucket.rs
@@ -908,13 +908,17 @@ impl Bucket {
     /// # }
     /// ```
     #[maybe_async::async_impl]
-    pub async fn get_object_range_to_writer<T: AsyncWrite + Send + Unpin, S: AsRef<str>>(
+    pub async fn get_object_range_to_writer<T, S>(
         &self,
         path: S,
         start: u64,
         end: Option<u64>,
         writer: &mut T,
-    ) -> Result<u16, S3Error> {
+    ) -> Result<u16, S3Error>
+    where
+        T: AsyncWrite + Send + Unpin + ?Sized,
+        S: AsRef<str>,
+    {
         if let Some(end) = end {
             assert!(start < end);
         }
@@ -925,7 +929,7 @@ impl Bucket {
     }
 
     #[maybe_async::sync_impl]
-    pub async fn get_object_range_to_writer<T: std::io::Write + Send, S: AsRef<str>>(
+    pub async fn get_object_range_to_writer<T: std::io::Write + Send + ?Sized, S: AsRef<str>>(
         &self,
         path: S,
         start: u64,
@@ -979,7 +983,7 @@ impl Bucket {
     /// # }
     /// ```
     #[maybe_async::async_impl]
-    pub async fn get_object_to_writer<T: AsyncWrite + Send + Unpin, S: AsRef<str>>(
+    pub async fn get_object_to_writer<T: AsyncWrite + Send + Unpin + ?Sized, S: AsRef<str>>(
         &self,
         path: S,
         writer: &mut T,
@@ -990,7 +994,7 @@ impl Bucket {
     }
 
     #[maybe_async::sync_impl]
-    pub fn get_object_to_writer<T: std::io::Write + Send, S: AsRef<str>>(
+    pub fn get_object_to_writer<T: std::io::Write + Send + ?Sized, S: AsRef<str>>(
         &self,
         path: S,
         writer: &mut T,
@@ -1098,7 +1102,7 @@ impl Bucket {
     /// # }
     /// ```
     #[maybe_async::async_impl]
-    pub async fn put_object_stream<R: AsyncRead + Unpin>(
+    pub async fn put_object_stream<R: AsyncRead + Unpin + ?Sized>(
         &self,
         reader: &mut R,
         s3_path: impl AsRef<str>,
@@ -1214,7 +1218,7 @@ impl Bucket {
     }
 
     #[maybe_async::async_impl]
-    async fn _put_object_stream_with_content_type<R: AsyncRead + Unpin>(
+    async fn _put_object_stream_with_content_type<R: AsyncRead + Unpin + ?Sized>(
         &self,
         reader: &mut R,
         s3_path: &str,
@@ -1316,7 +1320,7 @@ impl Bucket {
     }
 
     #[maybe_async::sync_impl]
-    fn _put_object_stream_with_content_type<R: Read>(
+    fn _put_object_stream_with_content_type<R: Read + ?Sized>(
         &self,
         reader: &mut R,
         s3_path: &str,

--- a/s3/src/request/async_std_backend.rs
+++ b/s3/src/request/async_std_backend.rs
@@ -114,7 +114,7 @@ impl<'a> Request for SurfRequest<'a> {
         ))
     }
 
-    async fn response_data_to_writer<T: AsyncWrite + Send + Unpin>(
+    async fn response_data_to_writer<T: AsyncWrite + Send + Unpin + ?Sized>(
         &self,
         writer: &mut T,
     ) -> Result<u16, S3Error> {

--- a/s3/src/request/blocking.rs
+++ b/s3/src/request/blocking.rs
@@ -111,7 +111,7 @@ impl<'a> Request for AttoRequest<'a> {
         Ok(ResponseData::new(body_vec, status_code, response_headers))
     }
 
-    fn response_data_to_writer<T: Write>(&self, writer: &mut T) -> Result<u16, S3Error> {
+    fn response_data_to_writer<T: Write + ?Sized>(&self, writer: &mut T) -> Result<u16, S3Error> {
         let mut response = self.response()?;
 
         let status_code = response.status();

--- a/s3/src/request/request_trait.rs
+++ b/s3/src/request/request_trait.rs
@@ -118,17 +118,17 @@ pub trait Request {
     async fn response(&self) -> Result<Self::Response, S3Error>;
     async fn response_data(&self, etag: bool) -> Result<ResponseData, S3Error>;
     #[cfg(feature = "with-tokio")]
-    async fn response_data_to_writer<T: tokio::io::AsyncWrite + Send + Unpin>(
+    async fn response_data_to_writer<T: tokio::io::AsyncWrite + Send + Unpin + ?Sized>(
         &self,
         writer: &mut T,
     ) -> Result<u16, S3Error>;
     #[cfg(feature = "with-async-std")]
-    async fn response_data_to_writer<T: futures_io::AsyncWrite + Send + Unpin>(
+    async fn response_data_to_writer<T: futures_io::AsyncWrite + Send + Unpin + ?Sized>(
         &self,
         writer: &mut T,
     ) -> Result<u16, S3Error>;
     #[cfg(feature = "sync")]
-    fn response_data_to_writer<T: std::io::Write + Send>(
+    fn response_data_to_writer<T: std::io::Write + Send + ?Sized>(
         &self,
         writer: &mut T,
     ) -> Result<u16, S3Error>;

--- a/s3/src/request/tokio_backend.rs
+++ b/s3/src/request/tokio_backend.rs
@@ -137,7 +137,7 @@ impl<'a> Request for HyperRequest<'a> {
         Ok(ResponseData::new(body_vec, status_code, response_headers))
     }
 
-    async fn response_data_to_writer<T: tokio::io::AsyncWrite + Send + Unpin>(
+    async fn response_data_to_writer<T: tokio::io::AsyncWrite + Send + Unpin + ?Sized>(
         &self,
         writer: &mut T,
     ) -> Result<u16, S3Error> {

--- a/s3/src/utils/mod.rs
+++ b/s3/src/utils/mod.rs
@@ -71,7 +71,7 @@ pub fn etag_for_path(path: impl AsRef<Path>) -> Result<String, S3Error> {
     Ok(etag)
 }
 
-pub fn read_chunk<R: Read>(reader: &mut R) -> Result<Vec<u8>, S3Error> {
+pub fn read_chunk<R: Read + ?Sized>(reader: &mut R) -> Result<Vec<u8>, S3Error> {
     let mut chunk = Vec::with_capacity(CHUNK_SIZE);
     let mut take = reader.take(CHUNK_SIZE as u64);
     take.read_to_end(&mut chunk)?;
@@ -80,7 +80,9 @@ pub fn read_chunk<R: Read>(reader: &mut R) -> Result<Vec<u8>, S3Error> {
 }
 
 #[cfg(any(feature = "with-tokio", feature = "with-async-std"))]
-pub async fn read_chunk_async<R: AsyncRead + Unpin>(reader: &mut R) -> Result<Vec<u8>, S3Error> {
+pub async fn read_chunk_async<R: AsyncRead + Unpin + ?Sized>(
+    reader: &mut R,
+) -> Result<Vec<u8>, S3Error> {
     let mut chunk = Vec::with_capacity(CHUNK_SIZE);
     let mut take = reader.take(CHUNK_SIZE as u64);
     take.read_to_end(&mut chunk).await?;


### PR DESCRIPTION
By relaxing size constraint.
Avoid double indirection. Instead of having to pass `&mut &mut dyn AsyncWrite`, we can pass `&mut dyn AsyncWrite`, for example. The use case for dynamic dispatch is object-safe traits. Static dispatch is unaffected.

`tokio` and `std` do the same thing, for example [tokio::io::copy](https://docs.rs/tokio/latest/tokio/io/fn.copy.html) and [std::io::copy](https://doc.rust-lang.org/stable/std/io/fn.copy.html).

[Example of the problem and desired outcome.](https://play.rust-lang.org/?version=stable&mode=debug&edition=2021&gist=b329ee2e751f2af663dc2fd72c362fdb)