### PR TITLE
Migrate to hyper v1 and http v1

### DIFF
--- a/aws-creds/Cargo.toml
+++ b/aws-creds/Cargo.toml
@@ -17,12 +17,12 @@ path = "src/lib.rs"
 [dependencies]
 thiserror = "1"
 home = "0.5"
-rust-ini = "0.19"
-attohttpc = { version = "0.26", default-features = false, features = [
+rust-ini = "0.21"
+attohttpc = { version = "0.28", default-features = false, features = [
     "json",
 ], optional = true }
 url = "2"
-quick-xml = { version = "0.30", features = ["serialize"] }
+quick-xml = { version = "0.31", features = ["serialize"] }
 serde = { version = "1", features = ["derive"] }
 time = { version = "^0.3.6", features = ["serde", "serde-well-known"] }
 log = "0.4"
@@ -35,5 +35,5 @@ native-tls-vendored = ["http-credentials", "attohttpc/tls-vendored"]
 rustls-tls = ["http-credentials", "attohttpc/tls-rustls"]
 
 [dev-dependencies]
-env_logger = "0.10"
+env_logger = "0.11"
 serde_json = "1"

--- a/s3/Cargo.toml
+++ b/s3/Cargo.toml
@@ -42,12 +42,10 @@ path = "../examples/gcs-tokio.rs"
 [dependencies]
 async-std = { version = "1", optional = true }
 async-trait = "0.1"
-attohttpc = { version = "0.26", optional = true, default-features = false }
-aws-creds = { version = "0.36", default-features = false }
-# aws-creds = { path = "../aws-creds", default-features = false }
-aws-region = "0.25.4"
-# aws-region = {path = "../aws-region"}
-base64 = "0.21"
+attohttpc = { version = "0.28", optional = true, default-features = false }
+aws-creds = { version = "0.36", path = "../aws-creds", default-features = false }
+aws-region = { version = "0.25.4", path = "../aws-region"}
+base64 = "0.22"
 cfg-if = "1"
 time = { version = "^0.3.6", features = ["formatting", "macros"] }
 futures = { version = "0.3", optional = true }
@@ -55,13 +53,14 @@ futures-io = { version = "0.3", optional = true }
 futures-util = { version = "0.3", optional = true, features = ["io"] }
 hex = "0.4"
 hmac = "0.12"
-http = "0.2"
-hyper = { version = "0.14", default-features = false, features = [
+http = "1.1"
+hyper = { version = "1.3", default-features = false, features = [
     "client",
     "http1",
-    "stream",
 ], optional = true }
-hyper-tls = { version = "0.5.0", default-features = false, optional = true }
+hyper-tls = { version = "0.6", default-features = false, optional = true }
+hyper-util = { version = "0.1", default-features = false, optional = true, features = ["http1", "client"] }
+http-body-util = "0.1"
 log = "0.4"
 maybe-async = { version = "0.2" }
 md5 = "0.7"
@@ -69,7 +68,7 @@ percent-encoding = "2"
 serde = "1"
 serde_json = "1"
 serde_derive = "1"
-quick-xml = { version = "0.30", features = ["serialize"] }
+quick-xml = { version = "0.31", features = ["serialize"] }
 sha2 = "0.10"
 thiserror = "1"
 surf = { version = "2", optional = true, default-features = false, features = [
@@ -92,6 +91,7 @@ use-tokio-native-tls = ["with-tokio", "aws-creds/native-tls"]
 with-tokio = [
     "hyper",
     "hyper-tls",
+    "hyper-util",
     "tokio",
     "tokio/fs",
     "tokio-stream",
@@ -120,5 +120,5 @@ tags = ["minidom"]
 tokio = { version = "1", features = ["rt", "rt-multi-thread", "macros", "fs"] }
 async-std = { version = "1", features = ["attributes"] }
 uuid = { version = "1", features = ["v4"] }
-env_logger = "0.10"
+env_logger = "0.11"
 anyhow = "1"

--- a/s3/Cargo.toml
+++ b/s3/Cargo.toml
@@ -60,7 +60,7 @@ hyper = { version = "1.3", default-features = false, features = [
 ], optional = true }
 hyper-tls = { version = "0.6", default-features = false, optional = true }
 hyper-util = { version = "0.1", default-features = false, optional = true, features = ["http1", "client"] }
-http-body-util = "0.1"
+http-body-util = { version = "0.1", optional = true }
 log = "0.4"
 maybe-async = { version = "0.2" }
 md5 = "0.7"
@@ -92,6 +92,7 @@ with-tokio = [
     "hyper",
     "hyper-tls",
     "hyper-util",
+    "http-body-util",
     "tokio",
     "tokio/fs",
     "tokio-stream",

--- a/s3/src/bucket.rs
+++ b/s3/src/bucket.rs
@@ -106,7 +106,12 @@ pub struct Bucket {
     path_style: bool,
     listobjects_v2: bool,
     #[cfg(feature = "with-tokio")]
-    http_client: Arc<hyper::Client<hyper_tls::HttpsConnector<hyper::client::HttpConnector>>>,
+    http_client: Arc<
+        hyper_util::client::legacy::Client<
+            hyper_tls::HttpsConnector<hyper_util::client::legacy::connect::HttpConnector>,
+            http_body_util::combinators::BoxBody<bytes::Bytes, S3Error>,
+        >,
+    >,
 }
 
 impl Bucket {
@@ -126,7 +131,12 @@ impl Bucket {
     #[cfg(feature = "with-tokio")]
     pub fn http_client(
         &self,
-    ) -> Arc<hyper::Client<hyper_tls::HttpsConnector<hyper::client::HttpConnector>>> {
+    ) -> Arc<
+        hyper_util::client::legacy::Client<
+            hyper_tls::HttpsConnector<hyper_util::client::legacy::connect::HttpConnector>,
+            http_body_util::combinators::BoxBody<bytes::Bytes, S3Error>,
+        >,
+    > {
         Arc::clone(&self.http_client)
     }
 }

--- a/s3/src/error.rs
+++ b/s3/src/error.rs
@@ -28,6 +28,12 @@ pub enum S3Error {
     #[error("hyper: {0}")]
     Hyper(#[from] hyper::Error),
     #[cfg(feature = "with-tokio")]
+    #[error("hyper-util client: {0}")]
+    HyperUtilClient(#[from] hyper_util::client::legacy::Error),
+    #[cfg(feature = "with-tokio")]
+    #[error("tokio mpsc reciever dropped")]
+    TokioMpscRecieverDropped,
+    #[cfg(feature = "with-tokio")]
     #[error("native-tls: {0}")]
     NativeTls(#[from] native_tls::Error),
     #[error("header to string: {0}")]

--- a/s3/src/request/tokio_backend.rs
+++ b/s3/src/request/tokio_backend.rs
@@ -2,10 +2,13 @@ extern crate base64;
 extern crate md5;
 
 use bytes::Bytes;
-use futures::TryStreamExt;
-use hyper::client::HttpConnector;
-use hyper::{Body, Client};
+use http_body_util::BodyExt;
+use http_body_util::{combinators::BoxBody, Full};
+use hyper::body::Incoming;
 use hyper_tls::HttpsConnector;
+use hyper_util::client::legacy::connect::HttpConnector;
+use hyper_util::client::legacy::Client;
+use hyper_util::rt::TokioExecutor;
 use maybe_async::maybe_async;
 use std::collections::HashMap;
 use time::OffsetDateTime;
@@ -17,11 +20,9 @@ use crate::command::HttpMethod;
 use crate::error::S3Error;
 use crate::utils::now_utc;
 
-use tokio_stream::StreamExt;
-
 pub fn client(
     request_timeout: Option<std::time::Duration>,
-) -> Result<Client<HttpsConnector<HttpConnector>>, S3Error> {
+) -> Result<Client<HttpsConnector<HttpConnector>, BoxBody<Bytes, S3Error>>, S3Error> {
     #[cfg(any(feature = "use-tokio-native-tls", feature = "tokio-rustls-tls"))]
     let mut tls_connector_builder = native_tls::TlsConnector::builder();
 
@@ -52,7 +53,7 @@ pub fn client(
     http_connector.enforce_http(false);
     let https_connector = HttpsConnector::from((http_connector, tls_connector));
 
-    Ok(Client::builder().build::<_, hyper::Body>(https_connector))
+    Ok(Client::builder(TokioExecutor::new()).build::<_, BoxBody<Bytes, S3Error>>(https_connector))
 }
 
 // Temporary structure for making a request
@@ -66,10 +67,10 @@ pub struct HyperRequest<'a> {
 
 #[maybe_async]
 impl<'a> Request for HyperRequest<'a> {
-    type Response = http::Response<Body>;
+    type Response = http::Response<Incoming>;
     type HeaderMap = http::header::HeaderMap;
 
-    async fn response(&self) -> Result<http::Response<Body>, S3Error> {
+    async fn response(&self) -> Result<Self::Response, S3Error> {
         // Build headers
         let headers = match self.headers().await {
             Ok(headers) => headers,
@@ -95,14 +96,20 @@ impl<'a> Request for HyperRequest<'a> {
                 request = request.header(header, value);
             }
 
-            request.body(Body::from(self.request_body()))?
+            let body = Full::new(Bytes::from(self.request_body()))
+                .map_err(|never| match never {})
+                .boxed();
+
+            request.body(body)?
         };
-        let response = client.request(request).await?;
+        let response = client
+            .request(request)
+            .await
+            .map_err(S3Error::HyperUtilClient)?;
 
         if cfg!(feature = "fail-on-err") && !response.status().is_success() {
             let status = response.status().as_u16();
-            let text =
-                String::from_utf8(hyper::body::to_bytes(response.into_body()).await?.into())?;
+            let text = String::from_utf8(response.into_body().collect().await?.to_bytes().into())?;
             return Err(S3Error::HttpFailWithBody(status, text));
         }
 
@@ -132,7 +139,7 @@ impl<'a> Request for HyperRequest<'a> {
                 Bytes::from("")
             }
         } else {
-            hyper::body::to_bytes(response.into_body()).await?
+            response.into_body().collect().await?.to_bytes()
         };
         Ok(ResponseData::new(body_vec, status_code, response_headers))
     }
@@ -142,25 +149,41 @@ impl<'a> Request for HyperRequest<'a> {
         writer: &mut T,
     ) -> Result<u16, S3Error> {
         use tokio::io::AsyncWriteExt;
-        let response = self.response().await?;
+        let mut response = self.response().await?;
 
-        let status_code = response.status();
-        let mut stream = response.into_body().into_stream();
+        let status_code: http::StatusCode = response.status();
 
-        while let Some(item) = stream.next().await {
-            writer.write_all(&item?).await?;
+        while let Some(item) = response.frame().await {
+            let frame = item?;
+
+            if let Some(chunk) = frame.data_ref() {
+                writer.write_all(chunk).await?;
+            }
         }
 
         Ok(status_code.as_u16())
     }
 
     async fn response_data_to_stream(&self) -> Result<ResponseDataStream, S3Error> {
-        let response = self.response().await?;
+        let mut response = self.response().await?;
         let status_code = response.status();
-        let stream = response.into_body().into_stream().map_err(S3Error::Hyper);
+
+        let (sender, reciever) = tokio::sync::mpsc::channel(100);
+
+        while let Some(item) = response.frame().await {
+            let frame = item?;
+
+            if let Some(chunk) = frame.data_ref() {
+                let bytes = chunk.to_owned();
+
+                if sender.send(Ok::<Bytes, S3Error>(bytes)).await.is_err() {
+                    return Err(S3Error::TokioMpscRecieverDropped);
+                }
+            }
+        }
 
         Ok(ResponseDataStream {
-            bytes: Box::pin(stream),
+            bytes: Box::pin(tokio_stream::wrappers::ReceiverStream::new(reciever)),
             status_code: status_code.as_u16(),
         })
     }


### PR DESCRIPTION
Hi, this PR updates hyper to v1 and http to v1. I'm not completely sure about the choices I made, so some things might have been overcomplicated. But it is somewhat hard to understand the new hyper.

I would be happy to be pointed out possible improvements. But for now it gives me the opportunity not to duplicate hyper `0.2` and `1.1` already now.

It also updates side dependencies that it's time to update. It's also worth thinking about updating edition to 2021.