### PR TITLE
Make BucketOwner `DisplayName` optional

### DIFF
--- a/s3/src/bucket_ops.rs
+++ b/s3/src/bucket_ops.rs
@@ -227,7 +227,7 @@ mod list_buckets {
         #[serde(rename = "ID")]
         pub id: String,
         #[serde(rename = "DisplayName")]
-        pub display_name: String,
+        pub display_name: Option<String>,
     }
 
     #[derive(Deserialize, Default, Clone, Debug)]


### PR DESCRIPTION
According to: https://docs.aws.amazon.com/AmazonS3/latest/API/API_Owner.html#API_Owner_Contents, only certain regions support `DisplayName` for the bucket. This causes problem for my bucket (eu-north-1) once I use `bucket.exists()`, it throws the following Error:
`S3(SerdeXml(Custom("missing field DisplayName")))`
Thus, it should be `Option<String>` to support all regions.