### PR TITLE
Support custom queries when generating presigned put URLs

### DIFF
--- a/s3/src/bucket.rs
+++ b/s3/src/bucket.rs
@@ -259,6 +259,7 @@ impl Bucket {
         path: S,
         expiry_secs: u32,
         custom_headers: Option<HeaderMap>,
+        custom_queries: Option<HashMap<String, String>>
     ) -> Result<String, S3Error> {
         validate_expiry(expiry_secs)?;
         let request = RequestImpl::new(
@@ -267,6 +268,7 @@ impl Bucket {
             Command::PresignPut {
                 expiry_secs,
                 custom_headers,
+                custom_queries
             },
         )
         .await?;
@@ -3059,7 +3061,7 @@ mod test {
         );
 
         let url = bucket
-            .presign_put(s3_path, 86400, Some(custom_headers))
+            .presign_put(s3_path, 86400, Some(custom_headers), None)
             .await
             .unwrap();
 

--- a/s3/src/command.rs
+++ b/s3/src/command.rs
@@ -101,6 +101,7 @@ pub enum Command<'a> {
     PresignPut {
         expiry_secs: u32,
         custom_headers: Option<HeaderMap>,
+        custom_queries: Option<HashMap<String, String>>,
     },
     PresignDelete {
         expiry_secs: u32,

--- a/s3/src/request/request_trait.rs
+++ b/s3/src/request/request_trait.rs
@@ -196,7 +196,8 @@ pub trait Request {
             Command::PresignPut {
                 expiry_secs,
                 custom_headers,
-            } => (expiry_secs, custom_headers, None),
+                custom_queries
+            } => (expiry_secs, custom_headers, custom_queries),
             Command::PresignDelete { expiry_secs } => (expiry_secs, None, None),
             _ => unreachable!(),
         };
@@ -262,7 +263,8 @@ pub trait Request {
             Command::PresignPut {
                 expiry_secs,
                 custom_headers,
-            } => (expiry_secs, custom_headers, None),
+                custom_queries
+            } => (expiry_secs, custom_headers, custom_queries),
             Command::PresignDelete { expiry_secs } => (expiry_secs, None, None),
             _ => unreachable!(),
         };


### PR DESCRIPTION
When generating pre-signed URLs for uploading multipart parts, the query must include the parameters `partNumber` and `uploadId`. Unfortunately, this is not possible with the current interface of this Crate, which assumes that signed URLs don't need to pass custom queries.

This PR adjusts the interface to accept custom queries, too.