### PR TITLE
Add bytes_mut and into_bytes for ResponseData

### DIFF
--- a/s3/src/request/request_trait.rs
+++ b/s3/src/request/request_trait.rs
@@ -80,6 +80,14 @@ impl ResponseData {
         &self.bytes
     }
 
+    pub fn bytes_mut(&mut self) -> &mut Bytes {
+        &mut self.bytes
+    }
+
+    pub fn into_bytes(self) -> Bytes {
+        self.bytes
+    }
+
     pub fn status_code(&self) -> u16 {
         self.status_code
     }


### PR DESCRIPTION
I needed these functions to avoid unnecessary copy so hopefully adding them is ok.