### PR TITLE
chore: use futures-util

### DIFF
--- a/s3/Cargo.toml
+++ b/s3/Cargo.toml
@@ -51,7 +51,7 @@ base64 = "0.22"
 block_on_proc = { version = "0.2", optional = true }
 bytes = { version = "1.2" }
 cfg-if = "1"
-futures = { version = "0.3", optional = true, default-features = false }
+futures-util = { version = "0.3", optional = true, default-features = false, features = ["alloc"] }
 hex = "0.4"
 hmac = "0.12"
 http = "1"
@@ -85,8 +85,8 @@ default = ["fail-on-err", "tags", "tokio-native-tls"]
 
 sync = ["attohttpc", "maybe-async/is_sync"]
 with-async-std-hyper = ["with-async-std", "surf/hyper-client"]
-with-async-std = ["async-std", "futures"]
-with-tokio = ["futures", "reqwest", "tokio", "tokio/fs", "tokio-stream"]
+with-async-std = ["async-std", "dep:futures-util"]
+with-tokio = ["dep:futures-util", "reqwest", "tokio", "tokio/fs", "tokio-stream"]
 
 blocking = ["block_on_proc", "tokio/rt", "tokio/rt-multi-thread"]
 fail-on-err = []

--- a/s3/src/bucket.rs
+++ b/s3/src/bucket.rs
@@ -1575,7 +1575,7 @@ impl Bucket {
         }
 
         // Wait for all chunks to finish (or fail)
-        let responses = futures::future::join_all(handles).await;
+        let responses = futures_util::future::join_all(handles).await;
 
         for response in responses {
             let response_data = response?;
@@ -3015,7 +3015,7 @@ mod test {
         #[cfg(feature = "with-async-std")]
         use async_std::stream::StreamExt;
         #[cfg(feature = "with-tokio")]
-        use futures::StreamExt;
+        use futures_util::stream::StreamExt;
         #[cfg(not(any(feature = "with-tokio", feature = "with-async-std")))]
         use std::fs::File;
         #[cfg(not(any(feature = "with-tokio", feature = "with-async-std")))]

--- a/s3/src/request/async_std_backend.rs
+++ b/s3/src/request/async_std_backend.rs
@@ -2,7 +2,7 @@ use async_std::io::Write as AsyncWrite;
 use async_std::io::{ReadExt, WriteExt};
 use async_std::stream::StreamExt;
 use bytes::Bytes;
-use futures::FutureExt;
+use futures_util::future::FutureExt;
 use std::collections::HashMap;
 
 use crate::bucket::Bucket;

--- a/s3/src/request/tokio_backend.rs
+++ b/s3/src/request/tokio_backend.rs
@@ -2,7 +2,7 @@ extern crate base64;
 extern crate md5;
 
 use bytes::Bytes;
-use futures::TryStreamExt;
+use futures_util::stream::TryStreamExt;
 use maybe_async::maybe_async;
 use std::collections::HashMap;
 use std::str::FromStr as _;


### PR DESCRIPTION
Instead of pulling the whole features crate, it's much better to just grab the necessary types from features-util which is smaller.