### PR TITLE
R2: EU jurisdiction endpoint

### DIFF
--- a/aws-region/src/region.rs
+++ b/aws-region/src/region.rs
@@ -133,14 +133,10 @@ pub enum Region {
     WaApSoutheast1,
     /// Wasabi ap-southeast-2
     WaApSoutheast2,
+    /// Cloudflare R2
+    R2 { account_id: String },
     /// Custom region
-    R2 {
-        account_id: String,
-    },
-    Custom {
-        region: String,
-        endpoint: String,
-    },
+    Custom { region: String, endpoint: String },
 }
 
 impl fmt::Display for Region {

--- a/aws-region/src/region.rs
+++ b/aws-region/src/region.rs
@@ -135,6 +135,8 @@ pub enum Region {
     WaApSoutheast2,
     /// Cloudflare R2
     R2 { account_id: String },
+    /// Cloudflare R2 EU jurisdiction
+    R2Eu { account_id: String },
     /// Custom region
     Custom { region: String, endpoint: String },
 }
@@ -195,6 +197,7 @@ impl fmt::Display for Region {
             OvhCaEastTor => write!(f, "ca-east-tor"),
             OvhSgp => write!(f, "sgp"),
             R2 { .. } => write!(f, "auto"),
+            R2Eu { .. } => write!(f, "auto"),
             Custom { ref region, .. } => write!(f, "{}", region),
         }
     }
@@ -315,6 +318,7 @@ impl Region {
             OvhCaEastTor => String::from("s3.ca-east-tor.io.cloud.ovh.net"),
             OvhSgp => String::from("s3.sgp.io.cloud.ovh.net"),
             R2 { ref account_id } => format!("{}.r2.cloudflarestorage.com", account_id),
+            R2Eu { ref account_id } => format!("{}.eu.r2.cloudflarestorage.com", account_id),
             Custom { ref endpoint, .. } => endpoint.to_string(),
         }
     }


### PR DESCRIPTION
R2 offers a separate endpoint for EU-jurisdiction-only buckets. I exposed this through a new region variant.

Additionally, this fixes the region comment on Custom and the normal R2 region.