### PR TITLE
feat: add impl AsyncRead for ResponseDataStream

### DIFF
--- a/s3/Cargo.toml
+++ b/s3/Cargo.toml
@@ -86,7 +86,7 @@ default = ["fail-on-err", "tags", "tokio-native-tls"]
 sync = ["attohttpc", "maybe-async/is_sync"]
 with-async-std-hyper = ["with-async-std", "surf/hyper-client"]
 with-async-std = ["async-std", "futures"]
-with-tokio = ["futures", "reqwest", "tokio", "tokio/fs", "tokio-stream"]
+with-tokio = ["futures/alloc", "reqwest", "tokio", "tokio/fs", "tokio-stream"]
 
 blocking = ["block_on_proc", "tokio/rt", "tokio/rt-multi-thread"]
 fail-on-err = []


### PR DESCRIPTION
Hi, I think `ResponseDataStream` is missing the implementation of `AsyncRead ` trait, which allows us to pass the stream to a reader instead of putting the whole file in memory

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/durch/rust-s3/410)
<!-- Reviewable:end -->
