### PR TITLE
Fix Bucket::get_object_range_to_writer() sync impl

### DIFF
--- a/s3/src/bucket.rs
+++ b/s3/src/bucket.rs
@@ -1224,7 +1224,7 @@ impl Bucket {
     }
 
     #[maybe_async::sync_impl]
-    pub async fn get_object_range_to_writer<T: std::io::Write + Send + ?Sized, S: AsRef<str>>(
+    pub fn get_object_range_to_writer<T: std::io::Write + Send + ?Sized, S: AsRef<str>>(
         &self,
         path: S,
         start: u64,


### PR DESCRIPTION
Fixes `Bucket::get_object_range_to_writer()` when using sync impl features. The function was incorrectly marked `async`, which this change removes.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/durch/rust-s3/413)
<!-- Reviewable:end -->
