### PR TITLE
bucket: ensure Bucket::exists() honours 'dangereous' config

### DIFF
--- a/s3/src/bucket.rs
+++ b/s3/src/bucket.rs
@@ -438,7 +438,15 @@ impl Bucket {
         credentials: Credentials,
     ) -> Result<crate::bucket_ops::ListBucketsResponse, S3Error> {
         let dummy_bucket = Bucket::new("", region, credentials)?.with_path_style();
-        let request = RequestImpl::new(&dummy_bucket, "", Command::ListBuckets).await?;
+        dummy_bucket.list_buckets_().await
+    }
+
+    /// Internally accessible non-static implementation of list_buckets
+    #[maybe_async::maybe_async]
+    async fn list_buckets_(
+        &self
+    ) -> Result<crate::bucket_ops::ListBucketsResponse, S3Error> {
+        let request = RequestImpl::new(self, "", Command::ListBuckets).await?;
         let response = request.response_data(false).await?;
 
         Ok(quick_xml::de::from_str::<
@@ -479,9 +487,10 @@ impl Bucket {
     /// ```
     #[maybe_async::maybe_async]
     pub async fn exists(&self) -> Result<bool, S3Error> {
-        let credentials = self.credentials().await?;
+        let mut dummy_bucket = self.clone();
+        dummy_bucket.name = "".into();
 
-        let response = Self::list_buckets(self.region.clone(), credentials).await?;
+        let response = dummy_bucket.list_buckets_().await?;
 
         Ok(response
             .bucket_names()


### PR DESCRIPTION
The following fails on connections that have invalid SSL certificates.  Other operations on the bucket succeed.

```
let bucket = Bucket::new("mybucket", region.clone(), credentials.clone())?
    .set_dangereous_config(true, false)?
    .with_path_style();

assert!(bucket.exists().unwrap());  // fails with 
```

The existing `exists()` implementation creates a `dummy_bucket` and calls a static method to lookup the buckets and find ours.  In doing so it discards most of the configuration in order to `""` null out the bucket name.

I've forced the issue by duplicating the `dummy_handle` via `clone()`.  There's probably a smarter way to do this though.

If the `name = ""` part isn't needed then `clone()` could be skipped altogether.