### PR TITLE
Add put_object_with_headers method to bucket

### DIFF
--- a/s3/src/command.rs
+++ b/s3/src/command.rs
@@ -93,6 +93,7 @@ pub enum Command<'a> {
     PutObject {
         content: &'a [u8],
         content_type: &'a str,
+        custom_headers: Option<HeaderMap>,
         multipart: Option<Multipart<'a>>,
     },
     PutObjectTagging {

--- a/s3/src/request/request_trait.rs
+++ b/s3/src/request/request_trait.rs
@@ -565,6 +565,15 @@ pub trait Request {
             headers.insert(k.clone(), v.clone());
         }
 
+        // Append custom headers for PUT request if any
+        if let Command::PutObject { custom_headers, .. } = self.command() {
+            if let Some(custom_headers) = custom_headers {
+                for (k, v) in custom_headers.iter() {
+                    headers.insert(k.clone(), v.clone());
+                }
+            }
+        }
+
         let host_header = self.host_header();
 
         headers.insert(HOST, host_header.parse()?);


### PR DESCRIPTION
Add two new methods to support uploading objects with custom HTTP headers on a per-request basis:
- **put_object_with_content_type_and_headers**: upload with explicit content-type and custom headers.
- **put_object_with_headers**: uploads an object with optional custom headers; uses `"application/octet-stream"` as the default `Content-Type`.

Custom headers are attached to the PUT request via the headers method in the request trait. Following the same design approach as the existing `put_object` and `put_object_with_content_type` methods.

**Use Case:**
Enable per-upload customization of HTTP headers such as Cache-Control, allowing control over caching.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/durch/rust-s3/425)
<!-- Reviewable:end -->
