### PR TITLE
fix(s3): exclude content-length for ListBuckets

### DIFF
--- a/s3/src/request/request_trait.rs
+++ b/s3/src/request/request_trait.rs
@@ -578,6 +578,7 @@ pub trait Request {
             Command::GetObject => {}
             Command::GetObjectTagging => {}
             Command::GetBucketLocation => {}
+            Command::ListBuckets => {}
             _ => {
                 headers.insert(
                     CONTENT_LENGTH,


### PR DESCRIPTION
## Problem
Garage S3 returns `400 Bad Request` when `content-length` is signed but not required (e.g., `ListBuckets`).

## Solution
- Skip `content-length` and `content-type` headers for:
  - `ListBuckets`

## Testing
Verified against Garage S3-compatible storage.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/durch/rust-s3/428)
<!-- Reviewable:end -->
