### PR TITLE
Ranges are closed, so the check should be start <= end, not start < end

### DIFF
--- a/s3/src/bucket.rs
+++ b/s3/src/bucket.rs
@@ -1186,7 +1186,7 @@ impl Bucket {
         end: Option<u64>,
     ) -> Result<ResponseData, S3Error> {
         if let Some(end) = end {
-            assert!(start < end);
+            assert!(start <= end);
         }
 
         let command = Command::GetObjectRange { start, end };
@@ -1247,7 +1247,7 @@ impl Bucket {
         S: AsRef<str>,
     {
         if let Some(end) = end {
-            assert!(start < end);
+            assert!(start <= end);
         }
 
         let command = Command::GetObjectRange { start, end };
@@ -1264,7 +1264,7 @@ impl Bucket {
         writer: &mut T,
     ) -> Result<u16, S3Error> {
         if let Some(end) = end {
-            assert!(start < end);
+            assert!(start <= end);
         }
 
         let command = Command::GetObjectRange { start, end };


### PR DESCRIPTION
The check in the ranged read functions is correct for a half-open range, but off-by-one for the closed ranges that the read functions are expecting. This prevents single-byte reads from working, because in a single-byte read, `start == end`. (Yes, single byte reads from S3 are stupid, but they should still work.)

This PR fixes the range checks.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/durch/rust-s3/434)
<!-- Reviewable:end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Adjusted S3 object range request validation to accept requests where start and end values are equal, enabling zero-length range retrieval.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->