### PR TITLE
Fix for SignatureDoesNotMatch Error in put_bucket_lifecycle

### DIFF
--- a/s3/src/request/request_trait.rs
+++ b/s3/src/request/request_trait.rs
@@ -770,7 +770,6 @@ pub trait Request {
             let digest = md5::compute(to_string(configuration)?.as_bytes());
             let hash = general_purpose::STANDARD.encode(digest.as_ref());
             headers.insert(HeaderName::from_static("content-md5"), hash.parse()?);
-            headers.remove("x-amz-content-sha256");
         } else if let Command::PutBucketCors {
             expected_bucket_owner,
             configuration,


### PR DESCRIPTION
Hello,

I recently upgraded the project from version 0.35 to 0.37, and after the upgrade I encountered a SignatureDoesNotMatch error when calling put_bucket_lifecycle.

Following the suggestions provided by Cursor, I modified the source code to address this issue. After applying the changes, the request now works as expected.

However, since I’m not very familiar with the signature logic, I’m not entirely sure whether my modification is the correct or recommended approach.

I would appreciate it if a maintainer could kindly review my changes and confirm whether it’s appropriate to merge this commit.

Thank you very much for your time and assistance.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/durch/rust-s3/435)
<!-- Reviewable:end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed S3 request header handling to properly maintain required headers during bucket lifecycle operations instead of incorrectly removing them.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->