### PR TITLE
Priorize ECS/EKS credentials over EC2's when available

### DIFF
--- a/aws-creds/src/error.rs
+++ b/aws-creds/src/error.rs
@@ -4,6 +4,8 @@ use thiserror::Error;
 pub enum CredentialsError {
     #[error("Not an AWS instance")]
     NotEc2,
+    #[error("Not a container")]
+    NotContainer,
     #[error("Config not found")]
     ConfigNotFound,
     #[error("Missing aws_access_key_id section in config")]


### PR DESCRIPTION
- Move container credentials logic out of the IMDSv1 function
- Priorize it over IMDSv2 like before #378

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/durch/rust-s3/441)
<!-- Reviewable:end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## New Features

* Added support for AWS credentials in containerized environments, with container credentials automatically checked as part of the credential fallback chain

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->