### PR TITLE
add custom_headers parameter to initiate_multipart_upload

### DIFF
--- a/s3/src/bucket.rs
+++ b/s3/src/bucket.rs
@@ -1664,7 +1664,7 @@ impl Bucket {
         }
 
         let msg = self
-            .initiate_multipart_upload(s3_path, content_type)
+            .initiate_multipart_upload(s3_path, content_type, custom_headers)
             .await?;
         let path = msg.key;
         let upload_id = &msg.upload_id;
@@ -1806,7 +1806,7 @@ impl Bucket {
         s3_path: &str,
         content_type: &str,
     ) -> Result<u16, S3Error> {
-        let msg = self.initiate_multipart_upload(s3_path, content_type)?;
+        let msg = self.initiate_multipart_upload(s3_path, content_type, None)?;
         let path = msg.key;
         let upload_id = &msg.upload_id;
 
@@ -1859,8 +1859,12 @@ impl Bucket {
         &self,
         s3_path: &str,
         content_type: &str,
+        custom_headers: Option<HeaderMap>,
     ) -> Result<InitiateMultipartUploadResponse, S3Error> {
-        let command = Command::InitiateMultipartUpload { content_type };
+        let command = Command::InitiateMultipartUpload {
+            content_type,
+            custom_headers,
+        };
         let request = RequestImpl::new(self, s3_path, command).await?;
         let response_data = request.response_data(false).await?;
         if response_data.status_code() >= 300 {
@@ -1877,8 +1881,12 @@ impl Bucket {
         &self,
         s3_path: &str,
         content_type: &str,
+        custom_headers: Option<HeaderMap>,
     ) -> Result<InitiateMultipartUploadResponse, S3Error> {
-        let command = Command::InitiateMultipartUpload { content_type };
+        let command = Command::InitiateMultipartUpload {
+            content_type,
+            custom_headers,
+        };
         let request = RequestImpl::new(self, s3_path, command)?;
         let response_data = request.response_data(false)?;
         if response_data.status_code() >= 300 {

--- a/s3/src/command.rs
+++ b/s3/src/command.rs
@@ -134,6 +134,7 @@ pub enum Command<'a> {
     },
     InitiateMultipartUpload {
         content_type: &'a str,
+        custom_headers: Option<HeaderMap>,
     },
     UploadPart {
         part_number: u32,
@@ -258,7 +259,7 @@ impl<'a> Command<'a> {
 
     pub fn content_type(&self) -> String {
         match self {
-            Command::InitiateMultipartUpload { content_type } => content_type.to_string(),
+            Command::InitiateMultipartUpload { content_type, .. } => content_type.to_string(),
             Command::PutObject { content_type, .. } => content_type.to_string(),
             Command::CompleteMultipartUpload { .. }
             | Command::PutBucketLifecycle { .. }

--- a/s3/src/request/request_trait.rs
+++ b/s3/src/request/request_trait.rs
@@ -696,6 +696,15 @@ pub trait Request {
             }
         }
 
+        // Append custom headers for InitiateMultipartUpload request if any
+        if let Command::InitiateMultipartUpload { custom_headers, .. } = self.command()
+            && let Some(custom_headers) = custom_headers
+        {
+            for (k, v) in custom_headers.iter() {
+                headers.insert(k.clone(), v.clone());
+            }
+        }
+
         let host_header = self.host_header();
 
         headers.insert(HOST, host_header.parse()?);

--- a/s3/src/request/request_trait.rs
+++ b/s3/src/request/request_trait.rs
@@ -770,7 +770,6 @@ pub trait Request {
             let digest = md5::compute(to_string(configuration)?.as_bytes());
             let hash = general_purpose::STANDARD.encode(digest.as_ref());
             headers.insert(HeaderName::from_static("content-md5"), hash.parse()?);
-            headers.remove("x-amz-content-sha256");
         } else if let Command::PutBucketCors {
             expected_bucket_owner,
             configuration,


### PR DESCRIPTION
This PR adds support for custom HTTP headers in the `initiate_multipart_upload` method, allowing users to pass custom headers (such as cache-control, metadata, storage class, etc.) when initiating multipart uploads to S3.

This feature aligns the `initiate_multipart_upload` API with the existing `put_object_with_headers` functionality, providing a consistent interface for setting custom headers across different upload methods.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/durch/rust-s3/446)
<!-- Reviewable:end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Custom HTTP headers can now be specified when initiating multipart uploads.

* **Breaking Changes**
  * Multipart upload initiation method signatures updated to include a custom headers parameter.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->