### PR TITLE
feat: add bulk delete (DeleteObjects) support

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,6 +134,7 @@ Each `GET` method has a `PUT` companion `sync` and `async` methods are generic o
 |                             |                                                                                                   |
 | --------------------------- | ------------------------------------------------------------------------------------------------- |
 | `async/sync/async-blocking` | [delete_object](https://docs.rs/rust-s3/latest/s3/bucket/struct.Bucket.html#method.delete_object) |
+| `async/sync/async-blocking` | [delete_objects](https://docs.rs/rust-s3/latest/s3/bucket/struct.Bucket.html#method.delete_objects) |
 
 #### Location
 

--- a/s3/src/bucket.rs
+++ b/s3/src/bucket.rs
@@ -2171,6 +2171,19 @@ impl Bucket {
             errors: Vec::new(),
         };
 
+        // Strip leading '/' from keys to match library convention.
+        // Other methods (put_object, delete_object, etc.) strip the leading
+        // slash when building the URL; we do the same for the XML body.
+        let objects: Vec<ObjectIdentifier> = objects
+            .into_iter()
+            .map(|mut obj| {
+                if let Some(stripped) = obj.key.strip_prefix('/') {
+                    obj.key = stripped.to_string();
+                }
+                obj
+            })
+            .collect();
+
         for chunk in objects.chunks(1000) {
             let data = DeleteObjectsRequest {
                 objects: chunk.to_vec(),

--- a/s3/src/serde_types.rs
+++ b/s3/src/serde_types.rs
@@ -439,7 +439,11 @@ pub struct DeleteObjectsRequest {
 
 impl fmt::Display for DeleteObjectsRequest {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "<Delete>").expect("Can't fail");
+        write!(
+            f,
+            r#"<Delete xmlns="http://s3.amazonaws.com/doc/2006-03-01/">"#
+        )
+        .expect("Can't fail");
         if self.quiet {
             write!(f, "<Quiet>true</Quiet>").expect("Can't fail");
         }
@@ -447,7 +451,8 @@ impl fmt::Display for DeleteObjectsRequest {
             let escaped_key = quick_xml::escape::escape(&obj.key);
             write!(f, "<Object><Key>{}</Key>", escaped_key).expect("Can't fail");
             if let Some(ref vid) = obj.version_id {
-                write!(f, "<VersionId>{}</VersionId>", vid).expect("Can't fail");
+                let escaped_vid = quick_xml::escape::escape(vid);
+                write!(f, "<VersionId>{}</VersionId>", escaped_vid).expect("Can't fail");
             }
             write!(f, "</Object>").expect("Can't fail");
         }
@@ -461,7 +466,7 @@ impl DeleteObjectsRequest {
     }
 
     pub fn is_empty(&self) -> bool {
-        self.to_string().len() == 0
+        self.objects.is_empty()
     }
 }
 
@@ -989,7 +994,7 @@ mod test {
         let se = request.to_string();
         assert_eq!(
             se,
-            r#"<Delete><Object><Key>file1.txt</Key></Object><Object><Key>file2.txt</Key></Object><Object><Key>file3.txt</Key><VersionId>v1</VersionId></Object></Delete>"#
+            r#"<Delete xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Object><Key>file1.txt</Key></Object><Object><Key>file2.txt</Key></Object><Object><Key>file3.txt</Key><VersionId>v1</VersionId></Object></Delete>"#
         )
     }
 
@@ -1003,7 +1008,7 @@ mod test {
         let se = request.to_string();
         assert_eq!(
             se,
-            r#"<Delete><Quiet>true</Quiet><Object><Key>file1.txt</Key></Object></Delete>"#
+            r#"<Delete xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Quiet>true</Quiet><Object><Key>file1.txt</Key></Object></Delete>"#
         )
     }
 
@@ -1017,7 +1022,7 @@ mod test {
         let se = request.to_string();
         assert_eq!(
             se,
-            r#"<Delete><Object><Key>file&amp;name&lt;&gt;.txt</Key></Object></Delete>"#
+            r#"<Delete xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Object><Key>file&amp;name&lt;&gt;.txt</Key></Object></Delete>"#
         )
     }
 


### PR DESCRIPTION
Implement the S3 Multi-Object Delete API, allowing up to 1000 objects to be deleted in a single request. Requests with more than 1000 objects are automatically batched.

- Add Command::DeleteObjects variant with XML body, Content-MD5 header
- Add ObjectIdentifier, DeleteObjectsRequest/Result serde types
- Add Bucket::delete_objects() with auto-chunking for >1000 keys
- Add unit tests for serialization, escaping, and deserialization
- Add integration tests for AWS and Minio
- Update README with delete_objects documentation

Closes #420

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/durch/rust-s3/448)
<!-- Reviewable:end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Bulk deletion of multiple S3 objects in a single operation with automatic batching and aggregated results.
  * Bounded parallelism for large transfers to improve reliability during streaming operations.

* **Documentation**
  * README updated with Multi-Object Delete API reference and usage guidance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->