### PR TITLE
Add support for AWS_CONTAINER_CREDENTIALS_FULL_URI (EKS Pod Identity Agent)

### DIFF
--- a/aws-creds/src/credentials.rs
+++ b/aws-creds/src/credentials.rs
@@ -187,6 +187,20 @@ fn http_get(url: &str) -> attohttpc::Result<attohttpc::Response> {
     builder.send()
 }
 
+/// Reads the container authorization token from environment.
+/// Checks `AWS_CONTAINER_AUTHORIZATION_TOKEN_FILE` first (file path), then
+/// `AWS_CONTAINER_AUTHORIZATION_TOKEN`. Used when fetching credentials from
+/// `AWS_CONTAINER_CREDENTIALS_FULL_URI` (e.g. EKS Pod Identity Agent).
+#[cfg(feature = "http-credentials")]
+fn get_container_authorization_token() -> Option<String> {
+    if let Ok(path) = env::var("AWS_CONTAINER_AUTHORIZATION_TOKEN_FILE") {
+        if let Ok(token) = std::fs::read_to_string(path) {
+            return Some(token.trim_end().to_string());
+        }
+    }
+    env::var("AWS_CONTAINER_AUTHORIZATION_TOKEN").ok()
+}
+
 impl Credentials {
     pub fn refresh(&mut self) -> Result<(), CredentialsError> {
         if let Some(expiration) = self.expiration {
@@ -327,18 +341,30 @@ impl Credentials {
         Credentials::from_env_specific(None, None, None, None)
     }
 
+    /// Load credentials from container metadata (ECS task role or EKS Pod Identity).
+    ///
+    /// Checks `AWS_CONTAINER_CREDENTIALS_RELATIVE_URI` first (ECS), then
+    /// `AWS_CONTAINER_CREDENTIALS_FULL_URI` (EKS Pod Identity Agent, etc.).
+    /// When using `FULL_URI`, optionally sends an `Authorization` header from
+    /// `AWS_CONTAINER_AUTHORIZATION_TOKEN_FILE` or `AWS_CONTAINER_AUTHORIZATION_TOKEN`.
     #[cfg(feature = "http-credentials")]
     pub fn from_container_credentials_provider() -> Result<Credentials, CredentialsError> {
-        let Ok(credentials_path) = env::var("AWS_CONTAINER_CREDENTIALS_RELATIVE_URI") else {
-            return Err(CredentialsError::NotContainer);
-        };
+        let (url, auth_token) =
+            if let Ok(relative_uri) = env::var("AWS_CONTAINER_CREDENTIALS_RELATIVE_URI") {
+                (format!("http://169.254.170.2{}", relative_uri), None)
+            } else if let Ok(full_uri) = env::var("AWS_CONTAINER_CREDENTIALS_FULL_URI") {
+                let token = get_container_authorization_token();
+                (full_uri, token)
+            } else {
+                return Err(CredentialsError::NotContainer);
+            };
 
-        let resp: CredentialsFromInstanceMetadata = apply_timeout(attohttpc::get(format!(
-            "http://169.254.170.2{}",
-            credentials_path
-        )))
-        .send()?
-        .json()?;
+        let mut request = apply_timeout(attohttpc::get(&url));
+        if let Some(ref token) = auth_token {
+            request = request.header("Authorization", token.as_str());
+        }
+
+        let resp: CredentialsFromInstanceMetadata = request.send()?.json()?;
 
         Ok(Credentials {
             access_key: Some(resp.access_key_id),

--- a/aws-creds/src/credentials.rs
+++ b/aws-creds/src/credentials.rs
@@ -575,15 +575,11 @@ aws_access_key_id = ENV_KEY
 aws_secret_access_key = ENV_SECRET
 "#;
         let file = create_test_credentials_file(content);
-
-        // Set the environment variable
-        env::set_var("AWS_SHARED_CREDENTIALS_FILE", file.path());
+        let path = file.path().to_string_lossy().to_string();
+        let _guard = EnvGuard::set("AWS_SHARED_CREDENTIALS_FILE", &path);
 
         let creds = Credentials::from_profile(None).unwrap();
         assert_eq!(creds.access_key.unwrap(), "ENV_KEY");
-
-        // Clean up
-        env::remove_var("AWS_SHARED_CREDENTIALS_FILE");
     }
 
     #[test]

--- a/aws-creds/src/credentials.rs
+++ b/aws-creds/src/credentials.rs
@@ -375,6 +375,26 @@ impl Credentials {
     /// `AWS_CONTAINER_CREDENTIALS_FULL_URI` (EKS Pod Identity Agent, etc.).
     /// When using `FULL_URI`, optionally sends an `Authorization` header from
     /// `AWS_CONTAINER_AUTHORIZATION_TOKEN_FILE` or `AWS_CONTAINER_AUTHORIZATION_TOKEN`.
+    ///
+    /// # Example
+    ///
+    /// ```no_run
+    /// use awscreds::Credentials;
+    ///
+    /// // ECS task role credentials use a relative path on the ECS metadata host.
+    /// std::env::set_var("AWS_CONTAINER_CREDENTIALS_RELATIVE_URI", "/v2/credentials/task-role");
+    /// let credentials = Credentials::from_container_credentials_provider()?;
+    ///
+    /// // EKS Pod Identity uses a full URI and may require an authorization token.
+    /// std::env::remove_var("AWS_CONTAINER_CREDENTIALS_RELATIVE_URI");
+    /// std::env::set_var(
+    ///     "AWS_CONTAINER_CREDENTIALS_FULL_URI",
+    ///     "http://169.254.170.23/v1/credentials",
+    /// );
+    /// std::env::set_var("AWS_CONTAINER_AUTHORIZATION_TOKEN", "pod-identity-token");
+    /// let credentials = Credentials::from_container_credentials_provider()?;
+    /// # Ok::<(), awscreds::error::CredentialsError>(())
+    /// ```
     #[cfg(feature = "http-credentials")]
     pub fn from_container_credentials_provider() -> Result<Credentials, CredentialsError> {
         let (url, auth_token) =

--- a/aws-creds/src/credentials.rs
+++ b/aws-creds/src/credentials.rs
@@ -669,6 +669,10 @@ aws_secret_access_key = SECRET
     #[cfg(feature = "http-credentials")]
     #[test]
     fn test_get_container_authorization_token_from_file() {
+        let _lock = CONTAINER_CREDENTIALS_TEST_LOCK
+            .get_or_init(|| Mutex::new(()))
+            .lock()
+            .unwrap();
         let mut file = NamedTempFile::new().unwrap();
         file.write_all(b"token-from-file").unwrap();
         file.flush().unwrap();
@@ -684,6 +688,10 @@ aws_secret_access_key = SECRET
     #[cfg(feature = "http-credentials")]
     #[test]
     fn test_get_container_authorization_token_from_env() {
+        let _lock = CONTAINER_CREDENTIALS_TEST_LOCK
+            .get_or_init(|| Mutex::new(()))
+            .lock()
+            .unwrap();
         let _guard = EnvGuard::set("AWS_CONTAINER_AUTHORIZATION_TOKEN", "token-from-env");
         let _u = EnvGuard::remove(&["AWS_CONTAINER_AUTHORIZATION_TOKEN_FILE"]);
         assert_eq!(
@@ -695,6 +703,10 @@ aws_secret_access_key = SECRET
     #[cfg(feature = "http-credentials")]
     #[test]
     fn test_get_container_authorization_token_file_precedence() {
+        let _lock = CONTAINER_CREDENTIALS_TEST_LOCK
+            .get_or_init(|| Mutex::new(()))
+            .lock()
+            .unwrap();
         let mut file = NamedTempFile::new().unwrap();
         file.write_all(b"token-from-file").unwrap();
         file.flush().unwrap();

--- a/aws-creds/src/credentials.rs
+++ b/aws-creds/src/credentials.rs
@@ -12,7 +12,7 @@ use std::sync::atomic::AtomicU32;
 use std::sync::atomic::Ordering;
 use std::time::Duration;
 use time::OffsetDateTime;
-use url::Url;
+use url::{Host, Url};
 
 /// AWS access credentials: access key, secret key, and optional token.
 ///
@@ -187,18 +187,46 @@ fn http_get(url: &str) -> attohttpc::Result<attohttpc::Response> {
     builder.send()
 }
 
+// EKS Pod Identity Agent link-local addresses documented by AWS:
+// https://docs.aws.amazon.com/eks/latest/userguide/pod-identities.html#pod-id-considerations
+#[cfg(feature = "http-credentials")]
+const EKS_POD_IDENTITY_AGENT_IPV4: [u8; 4] = [169, 254, 170, 23];
+#[cfg(feature = "http-credentials")]
+const EKS_POD_IDENTITY_AGENT_IPV6: [u16; 8] = [0xfd00, 0x0ec2, 0, 0, 0, 0, 0, 0x23];
+
 /// Reads the container authorization token from environment.
 /// Checks `AWS_CONTAINER_AUTHORIZATION_TOKEN_FILE` first (file path), then
 /// `AWS_CONTAINER_AUTHORIZATION_TOKEN`. Used when fetching credentials from
 /// `AWS_CONTAINER_CREDENTIALS_FULL_URI` (e.g. EKS Pod Identity Agent).
 #[cfg(feature = "http-credentials")]
-fn get_container_authorization_token() -> Option<String> {
+fn get_container_authorization_token() -> Result<Option<String>, CredentialsError> {
     if let Ok(path) = env::var("AWS_CONTAINER_AUTHORIZATION_TOKEN_FILE") {
-        if let Ok(token) = std::fs::read_to_string(path) {
-            return Some(token.trim_end().to_string());
-        }
+        let token = std::fs::read_to_string(path)?;
+        return Ok(Some(token.trim_end().to_string()));
     }
-    env::var("AWS_CONTAINER_AUTHORIZATION_TOKEN").ok()
+    Ok(env::var("AWS_CONTAINER_AUTHORIZATION_TOKEN").ok())
+}
+
+/// Returns whether it is safe to send a container authorization token to `url`.
+#[cfg(feature = "http-credentials")]
+fn validate_container_credentials_full_uri_for_auth_token(
+    url: &str,
+) -> Result<(), CredentialsError> {
+    let parsed = Url::parse(url)?;
+
+    if parsed.scheme() != "http" && parsed.scheme() != "https" {
+        return Err(CredentialsError::InvalidContainerCredentialsFullUri(
+            url.to_string(),
+        ));
+    }
+
+    match parsed.host() {
+        Some(Host::Ipv4(ip)) if ip.octets() == EKS_POD_IDENTITY_AGENT_IPV4 => Ok(()),
+        Some(Host::Ipv6(ip)) if ip.segments() == EKS_POD_IDENTITY_AGENT_IPV6 => Ok(()),
+        _ => Err(CredentialsError::InvalidContainerCredentialsFullUri(
+            url.to_string(),
+        )),
+    }
 }
 
 impl Credentials {
@@ -353,7 +381,10 @@ impl Credentials {
             if let Ok(relative_uri) = env::var("AWS_CONTAINER_CREDENTIALS_RELATIVE_URI") {
                 (format!("http://169.254.170.2{}", relative_uri), None)
             } else if let Ok(full_uri) = env::var("AWS_CONTAINER_CREDENTIALS_FULL_URI") {
-                let token = get_container_authorization_token();
+                let token = get_container_authorization_token()?;
+                if token.is_some() {
+                    validate_container_credentials_full_uri_for_auth_token(&full_uri)?;
+                }
                 (full_uri, token)
             } else {
                 return Err(CredentialsError::NotContainer);
@@ -680,9 +711,26 @@ aws_secret_access_key = SECRET
         let _guard = EnvGuard::set("AWS_CONTAINER_AUTHORIZATION_TOKEN_FILE", &path);
         let _u = EnvGuard::remove(&["AWS_CONTAINER_AUTHORIZATION_TOKEN"]);
         assert_eq!(
-            get_container_authorization_token(),
+            get_container_authorization_token().unwrap(),
             Some("token-from-file".to_string())
         );
+    }
+
+    #[cfg(feature = "http-credentials")]
+    #[test]
+    fn test_get_container_authorization_token_file_error_does_not_fallback_to_env() {
+        let _lock = CONTAINER_CREDENTIALS_TEST_LOCK
+            .get_or_init(|| Mutex::new(()))
+            .lock()
+            .unwrap();
+        let _guard_file = EnvGuard::set(
+            "AWS_CONTAINER_AUTHORIZATION_TOKEN_FILE",
+            "/path/that/does/not/exist/token",
+        );
+        let _guard_env = EnvGuard::set("AWS_CONTAINER_AUTHORIZATION_TOKEN", "token-from-env");
+
+        let result = get_container_authorization_token();
+        assert!(matches!(result, Err(CredentialsError::Io(_))));
     }
 
     #[cfg(feature = "http-credentials")]
@@ -695,7 +743,7 @@ aws_secret_access_key = SECRET
         let _guard = EnvGuard::set("AWS_CONTAINER_AUTHORIZATION_TOKEN", "token-from-env");
         let _u = EnvGuard::remove(&["AWS_CONTAINER_AUTHORIZATION_TOKEN_FILE"]);
         assert_eq!(
-            get_container_authorization_token(),
+            get_container_authorization_token().unwrap(),
             Some("token-from-env".to_string())
         );
     }
@@ -715,9 +763,68 @@ aws_secret_access_key = SECRET
         let _guard_env = EnvGuard::set("AWS_CONTAINER_AUTHORIZATION_TOKEN", "token-from-env");
         // File takes precedence over env var.
         assert_eq!(
-            get_container_authorization_token(),
+            get_container_authorization_token().unwrap(),
             Some("token-from-file".to_string())
         );
+    }
+
+    #[cfg(feature = "http-credentials")]
+    #[test]
+    fn test_container_credentials_rejects_auth_token_for_untrusted_full_uri() {
+        let _lock = CONTAINER_CREDENTIALS_TEST_LOCK
+            .get_or_init(|| Mutex::new(()))
+            .lock()
+            .unwrap();
+        let _rel = EnvGuard::remove(&["AWS_CONTAINER_CREDENTIALS_RELATIVE_URI"]);
+        let _full = EnvGuard::set(
+            "AWS_CONTAINER_CREDENTIALS_FULL_URI",
+            "https://example.com/v1/credentials",
+        );
+        let _token = EnvGuard::set("AWS_CONTAINER_AUTHORIZATION_TOKEN", "token-from-env");
+        let _file = EnvGuard::remove(&["AWS_CONTAINER_AUTHORIZATION_TOKEN_FILE"]);
+
+        let result = Credentials::from_container_credentials_provider();
+        assert!(matches!(
+            result,
+            Err(CredentialsError::InvalidContainerCredentialsFullUri(_))
+        ));
+    }
+
+    #[cfg(feature = "http-credentials")]
+    #[test]
+    fn test_container_credentials_auth_token_full_uri_allowlist() {
+        assert!(validate_container_credentials_full_uri_for_auth_token(
+            "http://169.254.170.23/v1/credentials",
+        )
+        .is_ok());
+        assert!(validate_container_credentials_full_uri_for_auth_token(
+            "http://[fd00:ec2::23]/v1/credentials",
+        )
+        .is_ok());
+        assert!(matches!(
+            validate_container_credentials_full_uri_for_auth_token(
+                "http://169.254.170.24/v1/credentials",
+            ),
+            Err(CredentialsError::InvalidContainerCredentialsFullUri(_))
+        ));
+        assert!(matches!(
+            validate_container_credentials_full_uri_for_auth_token(
+                "http://localhost/v1/credentials",
+            ),
+            Err(CredentialsError::InvalidContainerCredentialsFullUri(_))
+        ));
+        assert!(matches!(
+            validate_container_credentials_full_uri_for_auth_token(
+                "http://127.0.0.1/v1/credentials",
+            ),
+            Err(CredentialsError::InvalidContainerCredentialsFullUri(_))
+        ));
+        assert!(matches!(
+            validate_container_credentials_full_uri_for_auth_token(
+                "ftp://localhost/v1/credentials",
+            ),
+            Err(CredentialsError::InvalidContainerCredentialsFullUri(_))
+        ));
     }
 }
 

--- a/aws-creds/src/credentials.rs
+++ b/aws-creds/src/credentials.rs
@@ -604,6 +604,135 @@ aws_secret_access_key = SECRET
             CredentialsError::ConfigNotFound
         ));
     }
+
+    // Container credentials (RELATIVE_URI, FULL_URI, authorization token) - require http-credentials
+    #[cfg(feature = "http-credentials")]
+    #[test]
+    fn test_container_credentials_not_container_when_no_env() {
+        let _guard = EnvGuard::remove(&[
+            "AWS_CONTAINER_CREDENTIALS_RELATIVE_URI",
+            "AWS_CONTAINER_CREDENTIALS_FULL_URI",
+        ]);
+        let result = Credentials::from_container_credentials_provider();
+        assert!(matches!(result, Err(CredentialsError::NotContainer)));
+    }
+
+    #[cfg(feature = "http-credentials")]
+    #[test]
+    fn test_container_credentials_relative_uri_precedence() {
+        let _guard = EnvGuard::set(
+            "AWS_CONTAINER_CREDENTIALS_RELATIVE_URI",
+            "/v2/credentials/x",
+        );
+        let _guard2 = EnvGuard::set(
+            "AWS_CONTAINER_CREDENTIALS_FULL_URI",
+            "http://169.254.170.23/v1/credentials",
+        );
+        // With both set, RELATIVE_URI is used. Short timeout so request fails fast (no server).
+        let _timeout = set_request_timeout(Some(Duration::from_millis(10)));
+        let result = Credentials::from_container_credentials_provider();
+        let _ = set_request_timeout(_timeout);
+        assert!(result.is_err());
+        assert!(!matches!(result, Err(CredentialsError::NotContainer)));
+    }
+
+    #[cfg(feature = "http-credentials")]
+    #[test]
+    fn test_container_credentials_full_uri_used_when_no_relative() {
+        let _guard = EnvGuard::set(
+            "AWS_CONTAINER_CREDENTIALS_FULL_URI",
+            "http://169.254.170.23/v1/credentials",
+        );
+        let _rel = EnvGuard::remove(&["AWS_CONTAINER_CREDENTIALS_RELATIVE_URI"]);
+        // FULL_URI is used; short timeout so request fails fast (no server).
+        let _timeout = set_request_timeout(Some(Duration::from_millis(10)));
+        let result = Credentials::from_container_credentials_provider();
+        let _ = set_request_timeout(_timeout);
+        assert!(result.is_err());
+        assert!(!matches!(result, Err(CredentialsError::NotContainer)));
+    }
+
+    #[cfg(feature = "http-credentials")]
+    #[test]
+    fn test_get_container_authorization_token_from_file() {
+        let mut file = NamedTempFile::new().unwrap();
+        file.write_all(b"token-from-file").unwrap();
+        file.flush().unwrap();
+        let path = file.path().to_string_lossy().to_string();
+        let _guard = EnvGuard::set("AWS_CONTAINER_AUTHORIZATION_TOKEN_FILE", &path);
+        let _u = EnvGuard::remove(&["AWS_CONTAINER_AUTHORIZATION_TOKEN"]);
+        assert_eq!(
+            get_container_authorization_token(),
+            Some("token-from-file".to_string())
+        );
+    }
+
+    #[cfg(feature = "http-credentials")]
+    #[test]
+    fn test_get_container_authorization_token_from_env() {
+        let _guard = EnvGuard::set("AWS_CONTAINER_AUTHORIZATION_TOKEN", "token-from-env");
+        let _u = EnvGuard::remove(&["AWS_CONTAINER_AUTHORIZATION_TOKEN_FILE"]);
+        assert_eq!(
+            get_container_authorization_token(),
+            Some("token-from-env".to_string())
+        );
+    }
+
+    #[cfg(feature = "http-credentials")]
+    #[test]
+    fn test_get_container_authorization_token_file_precedence() {
+        let mut file = NamedTempFile::new().unwrap();
+        file.write_all(b"token-from-file").unwrap();
+        file.flush().unwrap();
+        let path = file.path().to_string_lossy().to_string();
+        let _guard_file = EnvGuard::set("AWS_CONTAINER_AUTHORIZATION_TOKEN_FILE", &path);
+        let _guard_env = EnvGuard::set("AWS_CONTAINER_AUTHORIZATION_TOKEN", "token-from-env");
+        // File takes precedence over env var.
+        assert_eq!(
+            get_container_authorization_token(),
+            Some("token-from-file".to_string())
+        );
+    }
+}
+
+/// Restores env vars when dropped. Used in tests to avoid leaking env state.
+#[cfg(test)]
+struct EnvGuard {
+    saved: Vec<(String, Option<String>)>,
+}
+
+#[cfg(test)]
+impl EnvGuard {
+    fn set(key: &str, value: &str) -> Self {
+        let saved = env::var(key).ok();
+        env::set_var(key, value);
+        Self {
+            saved: vec![(key.to_string(), saved)],
+        }
+    }
+    fn remove(keys: &[&str]) -> Self {
+        let mut saved = Vec::with_capacity(keys.len());
+        for key in keys {
+            let key = (*key).to_string();
+            let val = env::var(&key).ok();
+            env::remove_var(&key);
+            saved.push((key, val));
+        }
+        Self { saved }
+    }
+}
+
+#[cfg(test)]
+impl Drop for EnvGuard {
+    fn drop(&mut self) {
+        for (key, value) in &self.saved {
+            if let Some(ref v) = value {
+                env::set_var(key, v);
+            } else {
+                env::remove_var(key);
+            }
+        }
+    }
 }
 
 #[cfg(test)]

--- a/aws-creds/src/credentials.rs
+++ b/aws-creds/src/credentials.rs
@@ -536,7 +536,13 @@ struct CredentialsFromInstanceMetadata {
 mod tests {
     use super::*;
     use std::io::Write;
+    use std::sync::Mutex;
+    use std::sync::OnceLock;
     use tempfile::NamedTempFile;
+
+    /// Serializes container-credentials tests that touch RELATIVE_URI/FULL_URI so parallel runs don't race.
+    #[cfg(feature = "http-credentials")]
+    static CONTAINER_CREDENTIALS_TEST_LOCK: OnceLock<Mutex<()>> = OnceLock::new();
 
     fn create_test_credentials_file(content: &str) -> NamedTempFile {
         let mut file = NamedTempFile::new().unwrap();
@@ -605,6 +611,10 @@ aws_secret_access_key = SECRET
     #[cfg(feature = "http-credentials")]
     #[test]
     fn test_container_credentials_not_container_when_no_env() {
+        let _lock = CONTAINER_CREDENTIALS_TEST_LOCK
+            .get_or_init(|| Mutex::new(()))
+            .lock()
+            .unwrap();
         let _guard = EnvGuard::remove(&[
             "AWS_CONTAINER_CREDENTIALS_RELATIVE_URI",
             "AWS_CONTAINER_CREDENTIALS_FULL_URI",
@@ -616,6 +626,10 @@ aws_secret_access_key = SECRET
     #[cfg(feature = "http-credentials")]
     #[test]
     fn test_container_credentials_relative_uri_precedence() {
+        let _lock = CONTAINER_CREDENTIALS_TEST_LOCK
+            .get_or_init(|| Mutex::new(()))
+            .lock()
+            .unwrap();
         let _guard = EnvGuard::set(
             "AWS_CONTAINER_CREDENTIALS_RELATIVE_URI",
             "/v2/credentials/x",
@@ -635,6 +649,10 @@ aws_secret_access_key = SECRET
     #[cfg(feature = "http-credentials")]
     #[test]
     fn test_container_credentials_full_uri_used_when_no_relative() {
+        let _lock = CONTAINER_CREDENTIALS_TEST_LOCK
+            .get_or_init(|| Mutex::new(()))
+            .lock()
+            .unwrap();
         let _guard = EnvGuard::set(
             "AWS_CONTAINER_CREDENTIALS_FULL_URI",
             "http://169.254.170.23/v1/credentials",

--- a/aws-creds/src/error.rs
+++ b/aws-creds/src/error.rs
@@ -6,6 +6,9 @@ pub enum CredentialsError {
     NotEc2,
     #[error("Not a container")]
     NotContainer,
+    #[cfg(feature = "http-credentials")]
+    #[error("invalid AWS_CONTAINER_CREDENTIALS_FULL_URI for authorization token: {0}")]
+    InvalidContainerCredentialsFullUri(String),
     #[error("Config not found")]
     ConfigNotFound,
     #[error("Missing aws_access_key_id section in config")]


### PR DESCRIPTION

## Summary

Extends the container credentials provider to support `AWS_CONTAINER_CREDENTIALS_FULL_URI` and the optional authorization token environment variables (`AWS_CONTAINER_AUTHORIZATION_TOKEN`, `AWS_CONTAINER_AUTHORIZATION_TOKEN_FILE`). This allows applications to obtain credentials when running with **AWS EKS Pod Identity Agent** or other credential endpoints that use a full URI and bearer token (e.g. [AWS Greengrass Token Exchange](https://docs.aws.amazon.com/greengrass/v2/developerguide/token-exchange-service-component.html), custom sidecars).

## Why this is important

- **EKS Pod Identity** is the recommended way to give pods on Amazon EKS access to AWS APIs without IRSA or instance roles. The [EKS Pod Identity Agent](https://docs.aws.amazon.com/eks/latest/userguide/pod-id-agent-setup.html) runs as a DaemonSet and exposes credentials at a fixed endpoint (`http://169.254.170.23/v1/credentials`). The agent expects the client to set:
  - `AWS_CONTAINER_CREDENTIALS_FULL_URI` to that URL
  - `AWS_CONTAINER_AUTHORIZATION_TOKEN_FILE` (or `AWS_CONTAINER_AUTHORIZATION_TOKEN`) with the pod identity token
- Without `FULL_URI` support, `Credentials::default()` (and the rest of the chain) never considers the container provider when only these env vars are set, so pods using EKS Pod Identity get `NoCredentials` and cannot call S3 or other AWS services with this crate.

## Prior work

This builds on the container credentials support added in **[Priorize ECS/EKS credentials over EC2's when available (PR #441)](https://github.com/durch/rust-s3/pull/441)**. That PR introduced `from_container_credentials_provider()` and prioritized it over EC2 instance metadata, but only for `AWS_CONTAINER_CREDENTIALS_RELATIVE_URI` (used by ECS task IAM roles). This change adds the `FULL_URI` path and authorization token handling so both ECS-style and EKS Pod Identity–style container credentials are supported by the same provider.

## Changes

- **`aws-creds/src/credentials.rs`**
  - `from_container_credentials_provider()` now:
    1. Uses `AWS_CONTAINER_CREDENTIALS_RELATIVE_URI` if set (unchanged; builds `http://169.254.170.2{path}`).
    2. Otherwise uses `AWS_CONTAINER_CREDENTIALS_FULL_URI` if set.
  - When using `FULL_URI`, the request optionally includes an `Authorization` header:
    - Token is read from `AWS_CONTAINER_AUTHORIZATION_TOKEN_FILE` (file path) if set.
    - Otherwise from `AWS_CONTAINER_AUTHORIZATION_TOKEN`.
  - New helper `get_container_authorization_token()` implements the token lookup (file precedence over env).
- **Tests** (same file, `#[cfg(feature = "http-credentials")]`):
  - `test_container_credentials_not_container_when_no_env` – neither URI set → `NotContainer`.
  - `test_container_credentials_relative_uri_precedence` – both set → RELATIVE_URI is used.
  - `test_container_credentials_full_uri_used_when_no_relative` – only FULL_URI set → that URL is used.
  - `test_get_container_authorization_token_from_file` – token read from file.
  - `test_get_container_authorization_token_from_env` – token from env var.
  - `test_get_container_authorization_token_file_precedence` – file overrides env.

## Environment variables (after this PR)

| Variable | When used | Purpose |
|----------|-----------|---------|
| `AWS_CONTAINER_CREDENTIALS_RELATIVE_URI` | Checked first | Path only; host is `169.254.170.2` (ECS task role). |
| `AWS_CONTAINER_CREDENTIALS_FULL_URI` | If RELATIVE_URI unset | Full URL (e.g. EKS Pod Identity Agent). |
| `AWS_CONTAINER_AUTHORIZATION_TOKEN_FILE` | When using FULL_URI | Path to file containing token for `Authorization` header. |
| `AWS_CONTAINER_AUTHORIZATION_TOKEN` | When using FULL_URI, if _FILE unset | Token value for `Authorization` header. |

Behavior matches the [AWS SDK / container credential provider](https://docs.aws.amazon.com/sdkref/latest/guide/feature-container-credentials.html) (RELATIVE_URI precedence, FULL_URI, optional auth token).

## Testing

- `cargo test -p aws-creds --features http-credentials` – all new and existing tests pass.
- No change to the default credential chain order; container provider remains after env/profile/STS and before instance metadata.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/durch/rust-s3/449)
<!-- Reviewable:end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Support for an additional container credential source (EKS Pod Identity) and optional container authorization token usage.

* **Improvements**
  * Clearer precedence between container metadata sources, conditional token attachment only for trusted agent endpoints, and improved credential request handling and error reporting.

* **Tests**
  * Expanded tests for container credential flows, token-source precedence, host trust validation, and environment isolation during tests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->


* **Temp Usage**
  * If you want to use this in the interim you must add the following:
  ```toml
  [dependencies]
  rust-s3 = { git = 'https://github.com/LockedThread/rust-s3', branch = 'master', features = ['http-credentials'] }
  
  [patch.crates-io]
  # To force rust-s3 to use aws-creds from the fork, since rust-s3 does independent versioning.
  aws-creds = { git = "https://github.com/LockedThread/rust-s3", branch = "master" }
  ```