### PR TITLE
Fix ranged GET signing failure with Cloudflare R2

### DIFF
--- a/s3/src/command.rs
+++ b/s3/src/command.rs
@@ -244,6 +244,7 @@ impl<'a> Command<'a> {
                 | Command::CreateBucket { .. }
                 | Command::PutBucketLifecycle { .. }
                 | Command::PutBucketCors { .. }
+                | Command::DeleteObjects { .. }
         )
     }
 
@@ -460,5 +461,27 @@ mod tests {
             upload_id: "u",
         };
         assert!(upload.has_body());
+    }
+
+    /// `DeleteObjects` is a `POST` with an XML body listing the keys to
+    /// delete. It must be reported as body-bearing so `Content-Length`
+    /// reflects the payload size and `Content-Type: application/xml` is
+    /// signed; otherwise providers reject the request or the signature.
+    #[test]
+    fn delete_objects_has_body() {
+        use crate::serde_types::{DeleteObjectsRequest, ObjectIdentifier};
+        let cmd = Command::DeleteObjects {
+            data: DeleteObjectsRequest {
+                objects: vec![ObjectIdentifier {
+                    key: "a".to_string(),
+                    version_id: None,
+                }],
+                quiet: false,
+            },
+        };
+        assert!(cmd.has_body());
+        assert_eq!(cmd.http_verb(), HttpMethod::Post);
+        assert!(cmd.content_length().unwrap() > 0);
+        assert_eq!(cmd.content_type(), "application/xml");
     }
 }

--- a/s3/src/command.rs
+++ b/s3/src/command.rs
@@ -233,6 +233,22 @@ impl<'a> Command<'a> {
     /// stray `Content-Length: 0` / `Content-Type: text/plain` headers do
     /// not enter the AWS4-HMAC-SHA256 canonical request, which Cloudflare
     /// R2 rejects as a signature mismatch (notably for ranged `GET`s).
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use s3::command::Command;
+    ///
+    /// assert!(Command::PutObject {
+    ///     content: b"hi",
+    ///     content_type: "text/plain",
+    ///     custom_headers: None,
+    ///     multipart: None,
+    /// }
+    /// .has_body());
+    /// assert!(!Command::GetObject.has_body());
+    /// assert!(!Command::GetObjectRange { start: 0, end: Some(1023) }.has_body());
+    /// ```
     pub fn has_body(&self) -> bool {
         matches!(
             self,

--- a/s3/src/command.rs
+++ b/s3/src/command.rs
@@ -215,14 +215,31 @@ impl<'a> Command<'a> {
         }
     }
 
-    /// Whether this command carries a request body that should be reflected
-    /// in `Content-Length` and `Content-Type` headers during signing.
+    /// Whether this command should include `Content-Length` and `Content-Type`
+    /// headers in the signed request.
+    ///
+    /// Returns `true` for commands that serialize a request body, plus
+    /// `InitiateMultipartUpload`. The latter is a `POST` with an empty body
+    /// but is included because:
+    ///
+    /// - Google Cloud Storage rejects the request with HTTP 411 if
+    ///   `Content-Length` is omitted from a `POST`, even when the body is
+    ///   empty.
+    /// - The `Content-Type` value carried by `InitiateMultipartUpload` is
+    ///   not a description of the (empty) request body but the content type
+    ///   to associate with the eventual multipart object on the server.
+    ///
+    /// Body-less `GET`, `HEAD`, and `DELETE` commands return `false` so that
+    /// stray `Content-Length: 0` / `Content-Type: text/plain` headers do
+    /// not enter the AWS4-HMAC-SHA256 canonical request, which Cloudflare
+    /// R2 rejects as a signature mismatch (notably for ranged `GET`s).
     pub fn has_body(&self) -> bool {
         matches!(
             self,
             Command::PutObject { .. }
                 | Command::PutObjectTagging { .. }
                 | Command::UploadPart { .. }
+                | Command::InitiateMultipartUpload { .. }
                 | Command::CompleteMultipartUpload { .. }
                 | Command::CreateBucket { .. }
                 | Command::PutBucketLifecycle { .. }
@@ -381,5 +398,67 @@ impl<'a> Command<'a> {
             }
         };
         Ok(result)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Body-less `GET`s (notably ranged `GET`) must not advertise body
+    /// headers, otherwise Cloudflare R2 rejects the AWS4-HMAC-SHA256
+    /// signature for ranged downloads.
+    #[test]
+    fn ranged_get_does_not_have_body() {
+        let cmd = Command::GetObjectRange {
+            start: 0,
+            end: Some(1023),
+        };
+        assert!(!cmd.has_body());
+        assert!(!Command::GetObject.has_body());
+        assert!(!Command::HeadObject.has_body());
+        assert!(!Command::ListBuckets.has_body());
+    }
+
+    /// `DELETE` and `CopyObject` carry no request body.
+    #[test]
+    fn delete_and_copy_do_not_have_body() {
+        assert!(!Command::DeleteObject.has_body());
+        assert!(!Command::AbortMultipartUpload { upload_id: "u" }.has_body());
+        assert!(!Command::CopyObject { from: "x" }.has_body());
+    }
+
+    /// `InitiateMultipartUpload` is body-less but must still be reported as
+    /// having a body so that `Content-Length: 0` is sent. GCS returns HTTP
+    /// 411 on `POST` requests without `Content-Length`, even when the body
+    /// is empty.
+    #[test]
+    fn initiate_multipart_upload_has_body_for_gcs_compat() {
+        let cmd = Command::InitiateMultipartUpload {
+            content_type: "application/octet-stream",
+        };
+        assert!(cmd.has_body());
+        assert_eq!(cmd.http_verb(), HttpMethod::Post);
+        assert_eq!(cmd.content_length().unwrap(), 0);
+    }
+
+    /// Body-bearing commands report `has_body() == true` so signing
+    /// includes accurate `Content-Length` / `Content-Type`.
+    #[test]
+    fn body_bearing_commands_have_body() {
+        let put = Command::PutObject {
+            content: b"hello",
+            content_type: "text/plain",
+            custom_headers: None,
+            multipart: None,
+        };
+        assert!(put.has_body());
+
+        let upload = Command::UploadPart {
+            part_number: 1,
+            content: b"data",
+            upload_id: "u",
+        };
+        assert!(upload.has_body());
     }
 }

--- a/s3/src/command.rs
+++ b/s3/src/command.rs
@@ -215,6 +215,21 @@ impl<'a> Command<'a> {
         }
     }
 
+    /// Whether this command carries a request body that should be reflected
+    /// in `Content-Length` and `Content-Type` headers during signing.
+    pub fn has_body(&self) -> bool {
+        matches!(
+            self,
+            Command::PutObject { .. }
+                | Command::PutObjectTagging { .. }
+                | Command::UploadPart { .. }
+                | Command::CompleteMultipartUpload { .. }
+                | Command::CreateBucket { .. }
+                | Command::PutBucketLifecycle { .. }
+                | Command::PutBucketCors { .. }
+        )
+    }
+
     pub fn content_length(&self) -> Result<usize, S3Error> {
         let result = match &self {
             Command::CopyObject { from: _ } => 0,

--- a/s3/src/request/request_trait.rs
+++ b/s3/src/request/request_trait.rs
@@ -730,24 +730,24 @@ pub trait Request {
 
         headers.insert(HOST, host_header.parse()?);
 
-        match self.command() {
-            Command::CopyObject { from } => {
-                headers.insert(HeaderName::from_static("x-amz-copy-source"), from.parse()?);
-            }
-            Command::ListObjects { .. } => {}
-            Command::ListObjectsV2 { .. } => {}
-            Command::HeadObject => {}
-            Command::GetObject => {}
-            Command::GetObjectTagging => {}
-            Command::GetBucketLocation => {}
-            Command::ListBuckets => {}
-            _ => {
-                headers.insert(
-                    CONTENT_LENGTH,
-                    self.command().content_length()?.to_string().parse()?,
-                );
-                headers.insert(CONTENT_TYPE, self.command().content_type().parse()?);
-            }
+        if let Command::CopyObject { from } = self.command() {
+            headers.insert(HeaderName::from_static("x-amz-copy-source"), from.parse()?);
+        }
+
+        // Include content-length and content-type only for commands that
+        // either carry a request body or are otherwise required by some
+        // providers to advertise these headers (see Command::has_body).
+        // Body-less GET/HEAD/DELETE/CopyObject must not sign these headers,
+        // otherwise Cloudflare R2 rejects the AWS4-HMAC-SHA256 signature
+        // because the empty content-length value corrupts the canonical
+        // request. InitiateMultipartUpload is included because GCS returns
+        // HTTP 411 on a POST without Content-Length, even with an empty body.
+        if self.command().has_body() {
+            headers.insert(
+                CONTENT_LENGTH,
+                self.command().content_length()?.to_string().parse()?,
+            );
+            headers.insert(CONTENT_TYPE, self.command().content_type().parse()?);
         }
         headers.insert(
             HeaderName::from_static("x-amz-content-sha256"),


### PR DESCRIPTION
## Problem

`get_object_range` (ranged GET) requests fail with `SignatureDoesNotMatch` on Cloudflare R2.

The `headers()` method in `request_trait.rs` had a skip-list of commands that should not include `content-length` and `content-type` headers. `GetObjectRange` was missing from this list, so it fell through to the catch-all `_ =>` arm that adds `content-length: 0` and `content-type: text/plain`.

These empty/meaningless headers get included in the AWS4-HMAC-SHA256 canonical request. AWS S3 happens to tolerate this, but Cloudflare R2 rejects the signature because the canonical request doesn't match what R2 computes server-side.

The same class of bug also affected other body-less commands routed through PUT/POST/DELETE (`DeleteObject`, `AbortMultipartUpload`, `InitiateMultipartUpload`, etc.).

## Fix

Added a `has_body()` helper on `Command` that returns `true` only for commands that actually serialize request content (`PutObject`, `UploadPart`, `CompleteMultipartUpload`, `CreateBucket`, `PutBucketLifecycle`, `PutBucketCors`, `PutObjectTagging`). The header insertion now checks `has_body()` instead of using a skip-list or matching on the HTTP verb. This prevents the same bug from happening if new body-less commands are added in the future.

## Testing

All existing tests pass. Verified the fix against a real Cloudflare R2 bucket: ranged GET downloads that were failing with `SignatureDoesNotMatch` now succeed.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/durch/rust-s3/452)
<!-- Reviewable:end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Request header logic updated so copy-source is handled separately and content headers are only added for requests that carry a body.

* **Behavior**
  * Broadened recognition of which S3 operations include a request body (uploads, multipart flows, bucket creation and certain bucket settings), reducing signature mismatches for ranged/other body-less requests.

* **Tests**
  * Added tests validating body-detection and signing/header behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->