### PR TITLE
Fix presign tests: use fake credentials instead of minio env vars

### DIFF
--- a/s3/src/bucket.rs
+++ b/s3/src/bucket.rs
@@ -3142,6 +3142,28 @@ mod test {
         .with_path_style()
     }
 
+    /// Bucket with hardcoded fake credentials for tests that only exercise
+    /// local signing logic and never hit the network.
+    fn test_presign_bucket() -> Box<Bucket> {
+        Bucket::new(
+            "rust-s3",
+            Region::Custom {
+                region: "us-east-1".to_owned(),
+                endpoint: "http://localhost:9000".to_owned(),
+            },
+            Credentials::new(
+                Some("test_access_key"),
+                Some("test_secret_key"),
+                None,
+                None,
+                None,
+            )
+            .unwrap(),
+        )
+        .unwrap()
+        .with_path_style()
+    }
+
     #[allow(dead_code)]
     fn test_digital_ocean_bucket() -> Box<Bucket> {
         Bucket::new("rust-s3", Region::DoFra1, test_digital_ocean_credentials()).unwrap()
@@ -3794,7 +3816,7 @@ mod test {
     )]
     async fn test_presign_put() {
         let s3_path = "/test/test.file";
-        let bucket = test_minio_bucket();
+        let bucket = test_presign_bucket();
 
         let mut custom_headers = HeaderMap::new();
         custom_headers.insert(
@@ -3822,7 +3844,7 @@ mod test {
     async fn test_presign_post() {
         use std::borrow::Cow;
 
-        let bucket = test_minio_bucket();
+        let bucket = test_presign_bucket();
 
         // Policy from sample
         let policy = PostPolicy::new(86400)
@@ -3849,7 +3871,7 @@ mod test {
     )]
     async fn test_presign_get() {
         let s3_path = "/test/test.file";
-        let bucket = test_minio_bucket();
+        let bucket = test_presign_bucket();
 
         let url = bucket.presign_get(s3_path, 86400, None).await.unwrap();
         assert!(url.contains("/test/test.file?"))
@@ -3865,7 +3887,7 @@ mod test {
     )]
     async fn test_presign_delete() {
         let s3_path = "/test/test.file";
-        let bucket = test_minio_bucket();
+        let bucket = test_presign_bucket();
 
         let url = bucket.presign_delete(s3_path, 86400).await.unwrap();
         assert!(url.contains("/test/test.file?"))


### PR DESCRIPTION
## Problem

`make ci` (and `cargo test`) fails on a clean checkout because 4 presign tests panic trying to read `MINIO_ACCESS_KEY_ID` from the environment:

- `test_presign_get`
- `test_presign_put`
- `test_presign_post`
- `test_presign_delete`

## Fix

These tests only exercise local signing logic and never hit the network, so they don't actually need a running minio instance. Switched them from `test_minio_bucket()` (which reads env vars) to a new `test_presign_bucket()` helper with hardcoded fake credentials, following the same pattern already used by `test_presign_url_standard_ports`.

This keeps the tests in the default (non-ignored) suite so they provide CI coverage for presign PUT/POST/GET/DELETE.

## Verification

`make ci` passes clean after this change.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/durch/rust-s3/453)
<!-- Reviewable:end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Presign-related tests updated to use a new local test bucket helper targeting http://localhost:9000; no test assertions or public APIs changed.

Note: Internal testing update only; no user-facing changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->