### PR TITLE
fix: Add new feature flags to aws-creds and rust-s3 to allow for ring support

### DIFF
--- a/aws-creds/Cargo.toml
+++ b/aws-creds/Cargo.toml
@@ -33,6 +33,7 @@ http-credentials = ["attohttpc"]
 native-tls = ["http-credentials", "attohttpc/tls"]
 native-tls-vendored = ["http-credentials", "attohttpc/tls-vendored"]
 rustls-tls = ["http-credentials", "attohttpc/tls-rustls"]
+rustls-tls-ring = ["http-credentials", "attohttpc/tls-rustls-webpki-roots-ring"]
 
 [dev-dependencies]
 env_logger = "0.11"

--- a/s3/Cargo.toml
+++ b/s3/Cargo.toml
@@ -97,6 +97,7 @@ http-credentials = ["aws-creds/http-credentials"]
 
 tokio-native-tls = ["aws-creds/native-tls", "reqwest/native-tls", "with-tokio"]
 tokio-rustls-tls = ["aws-creds/rustls-tls", "reqwest/rustls-tls", "with-tokio"]
+tokio-rustls-tls-ring = ["aws-creds/rustls-tls-ring", "reqwest/rustls-tls", "with-tokio"]
 
 async-std-native-tls = [
     "aws-creds/native-tls",


### PR DESCRIPTION
Currently, enabling rustls TLS in aws-creds (`rustls-tls`) and rust-s3
(`tokio-rustls-tls`) hardcodes the aws-lc-rs crypto provider via
`attohttpc/tls-rustls`. This makes it impossible for downstream crates
to use ring as their sole crypto provider, both providers end up
compiled into the binary.

This PR adds ring-specific feature flags:

- `aws-creds`: `rustls-tls-ring` - uses `attohttpc/tls-rustls-webpki-roots-ring` instead of `attohttpc/tls-rustls`
- `rust-s3`: `tokio-rustls-tls-ring` - uses `aws-creds/rustls-tls-ring` instead of `aws-creds/rustls-tls`

The existing `rustls-tls` and `tokio-rustls-tls` features are unchanged
for backwards compatibility.

## Why this matters

Compiling two crypto providers increases build times and binary size
with no runtime benefit. Crates that already use ring (e.g. via reqwest
0.12 or an explicit `rustls/ring` dep) currently have no way to avoid
pulling in aws-lc-sys transitively through rust-s3.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/durch/rust-s3/454)
<!-- Reviewable:end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `rustls-tls-ring` feature flag for alternative TLS configuration in the `aws-creds` crate
  * Added `tokio-rustls-tls-ring` feature flag for async TLS support in the `s3` crate

<!-- end of auto-generated comment: release notes by coderabbit.ai -->