### PR TITLE
Fix HeadObject body headers

### DIFF
--- a/s3/src/request/blocking.rs
+++ b/s3/src/request/blocking.rs
@@ -240,4 +240,29 @@ mod tests {
 
         Ok(())
     }
+
+    #[test]
+    fn head_object_omits_body_headers_from_request_and_signature() -> Result<()> {
+        let region = "custom-region".parse()?;
+        let bucket = Bucket::new("my-first-bucket", region, fake_credentials())?;
+        let request = AttoRequest::new(&bucket, "/my-first/path", Command::HeadObject).unwrap();
+
+        let headers = request.headers().unwrap();
+
+        assert!(!headers.contains_key("Content-Length"));
+        assert!(!headers.contains_key("Content-Type"));
+        assert!(headers.contains_key("x-amz-content-sha256"));
+
+        let authorization = headers.get("Authorization").unwrap().to_str()?;
+        let signed_headers = authorization
+            .split("SignedHeaders=")
+            .nth(1)
+            .and_then(|value| value.split(',').next())
+            .unwrap();
+
+        assert!(!signed_headers.contains("content-length"));
+        assert!(!signed_headers.contains("content-type"));
+
+        Ok(())
+    }
 }

--- a/s3/src/request/request_trait.rs
+++ b/s3/src/request/request_trait.rs
@@ -711,6 +711,7 @@ pub trait Request {
             }
             Command::ListObjects { .. } => {}
             Command::ListObjectsV2 { .. } => {}
+            Command::HeadObject => {}
             Command::GetObject => {}
             Command::GetObjectTagging => {}
             Command::GetBucketLocation => {}


### PR DESCRIPTION
## Linked issue
Fixes #450.

## Problem
`Bucket::head_object` builds its request through the common request header path. The generic fallback branch added `Content-Length: 0` and `Content-Type: text/plain` for commands that are not explicitly exempted. `GetObject` was exempted, but `HeadObject` was not, so HEAD requests emitted and signed unnecessary body headers.

## Solution
Add `Command::HeadObject` to the same narrow no-body-header branch used by `GetObject`/listing-style commands. This avoids PR #452's broader `has_body()` style change and leaves upload, multipart initiation/completion, GCS-related multipart paths, and other body-bearing commands untouched.

## Focused verification
- `cargo test -p rust-s3 --no-default-features --features sync head_object_omits_body_headers_from_request_and_signature -- --nocapture`
  - Result: passed; 1 passed, 0 failed.
- `cargo test -p rust-s3 --no-default-features --features sync request::blocking::tests -- --nocapture`
  - Result: failed in two pre-existing path-style host assertions; the new `head_object_omits_body_headers_from_request_and_signature` test passed. The failures assert path-style host behavior and are unrelated to HeadObject/body headers.

## Risk notes
- Signing risk: intentionally changes the HeadObject canonical signed header set by removing `content-length` and `content-type`; regression coverage asserts those headers are absent both from the request and from `SignedHeaders` while preserving `x-amz-content-sha256`.
- Provider/runtime cordons: change is in the shared request trait header construction, so it applies across sync/tokio/async-std backends. No URL construction, credential resolution, security token handling, request payload SHA256, multipart upload, or GCS-specific multipart behavior was changed.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/durch/rust-s3/455)
<!-- Reviewable:end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * HEAD Object requests now correctly exclude Content-Length and Content-Type from both the sent request and the signature, improving API compliance.

* **Tests**
  * Added a unit test that verifies HEAD Object requests omit body-related headers from request headers and the signed headers list.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->