### PR TITLE
Fix ResponseDataStream small-buffer reads

### DIFF
--- a/s3/src/request/request_trait.rs
+++ b/s3/src/request/request_trait.rs
@@ -21,11 +21,10 @@ use http::header::{
 };
 use std::fmt::Write as _;
 
-#[cfg(feature = "with-async-std")]
-use async_std::stream::Stream;
-
-#[cfg(feature = "with-tokio")]
-use tokio_stream::Stream;
+#[cfg(any(feature = "with-tokio", feature = "with-async-std"))]
+use futures_util::Stream;
+#[cfg(any(feature = "with-tokio", feature = "with-async-std"))]
+use futures_util::stream::{self, StreamExt};
 
 #[derive(Debug)]
 
@@ -126,28 +125,39 @@ impl tokio::io::AsyncRead for ResponseDataStream {
         cx: &mut std::task::Context<'_>,
         buf: &mut tokio::io::ReadBuf<'_>,
     ) -> std::task::Poll<std::io::Result<()>> {
-        // Poll the stream for the next chunk of bytes
-        match Stream::poll_next(self.bytes.as_mut(), cx) {
-            std::task::Poll::Ready(Some(Ok(chunk))) => {
-                // Write as much of the chunk as fits in the buffer
-                let amt = std::cmp::min(chunk.len(), buf.remaining());
-                buf.put_slice(&chunk[..amt]);
+        if buf.remaining() == 0 {
+            return std::task::Poll::Ready(Ok(()));
+        }
 
-                // AIDEV-NOTE: Bytes that don't fit in the buffer are discarded from this chunk.
-                // This is expected AsyncRead behavior - consumers should use appropriately sized
-                // buffers or wrap in BufReader for efficiency with small reads.
+        loop {
+            match Stream::poll_next(self.bytes.as_mut(), cx) {
+                std::task::Poll::Ready(Some(Ok(chunk))) => {
+                    if chunk.is_empty() {
+                        continue;
+                    }
 
-                std::task::Poll::Ready(Ok(()))
+                    let amt = std::cmp::min(chunk.len(), buf.remaining());
+                    buf.put_slice(&chunk[..amt]);
+
+                    if amt < chunk.len() {
+                        let remainder = chunk.slice(amt..);
+                        let previous_stream =
+                            std::mem::replace(&mut self.bytes, Box::pin(stream::empty()));
+                        self.bytes = Box::pin(
+                            stream::once(async move { Ok(remainder) }).chain(previous_stream),
+                        );
+                    }
+
+                    return std::task::Poll::Ready(Ok(()));
+                }
+                std::task::Poll::Ready(Some(Err(error))) => {
+                    return std::task::Poll::Ready(Err(std::io::Error::other(error)));
+                }
+                std::task::Poll::Ready(None) => {
+                    return std::task::Poll::Ready(Ok(()));
+                }
+                std::task::Poll::Pending => return std::task::Poll::Pending,
             }
-            std::task::Poll::Ready(Some(Err(error))) => {
-                // Convert S3Error to io::Error
-                std::task::Poll::Ready(Err(std::io::Error::other(error)))
-            }
-            std::task::Poll::Ready(None) => {
-                // Stream is exhausted, signal EOF by returning Ok(()) with no bytes written
-                std::task::Poll::Ready(Ok(()))
-            }
-            std::task::Poll::Pending => std::task::Poll::Pending,
         }
     }
 }
@@ -159,28 +169,39 @@ impl async_std::io::Read for ResponseDataStream {
         cx: &mut std::task::Context<'_>,
         buf: &mut [u8],
     ) -> std::task::Poll<std::io::Result<usize>> {
-        // Poll the stream for the next chunk of bytes
-        match Stream::poll_next(self.bytes.as_mut(), cx) {
-            std::task::Poll::Ready(Some(Ok(chunk))) => {
-                // Write as much of the chunk as fits in the buffer
-                let amt = std::cmp::min(chunk.len(), buf.len());
-                buf[..amt].copy_from_slice(&chunk[..amt]);
+        if buf.is_empty() {
+            return std::task::Poll::Ready(Ok(0));
+        }
 
-                // AIDEV-NOTE: Bytes that don't fit in the buffer are discarded from this chunk.
-                // This is expected AsyncRead behavior - consumers should use appropriately sized
-                // buffers or wrap in BufReader for efficiency with small reads.
+        loop {
+            match Stream::poll_next(self.bytes.as_mut(), cx) {
+                std::task::Poll::Ready(Some(Ok(chunk))) => {
+                    if chunk.is_empty() {
+                        continue;
+                    }
 
-                std::task::Poll::Ready(Ok(amt))
+                    let amt = std::cmp::min(chunk.len(), buf.len());
+                    buf[..amt].copy_from_slice(&chunk[..amt]);
+
+                    if amt < chunk.len() {
+                        let remainder = chunk.slice(amt..);
+                        let previous_stream =
+                            std::mem::replace(&mut self.bytes, Box::pin(stream::empty()));
+                        self.bytes = Box::pin(
+                            stream::once(async move { Ok(remainder) }).chain(previous_stream),
+                        );
+                    }
+
+                    return std::task::Poll::Ready(Ok(amt));
+                }
+                std::task::Poll::Ready(Some(Err(error))) => {
+                    return std::task::Poll::Ready(Err(std::io::Error::other(error)));
+                }
+                std::task::Poll::Ready(None) => {
+                    return std::task::Poll::Ready(Ok(0));
+                }
+                std::task::Poll::Pending => return std::task::Poll::Pending,
             }
-            std::task::Poll::Ready(Some(Err(error))) => {
-                // Convert S3Error to io::Error
-                std::task::Poll::Ready(Err(std::io::Error::other(error)))
-            }
-            std::task::Poll::Ready(None) => {
-                // Stream is exhausted, signal EOF by returning 0 bytes read
-                std::task::Poll::Ready(Ok(0))
-            }
-            std::task::Poll::Pending => std::task::Poll::Pending,
         }
     }
 }
@@ -875,11 +896,9 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_async_read_with_small_buffer() {
-        // Create a stream with a large chunk
-        let chunks = vec![Ok(Bytes::from(
-            "This is a much longer string that won't fit in a small buffer",
-        ))];
+    async fn test_async_read_with_small_buffer_preserves_large_chunk() {
+        let expected = b"This is a much longer string that won't fit in a small buffer";
+        let chunks = vec![Ok(Bytes::copy_from_slice(expected))];
 
         let stream = stream::iter(chunks);
         let data_stream: DataStream = Box::pin(stream);
@@ -889,17 +908,18 @@ mod tests {
             status_code: 200,
         };
 
-        // Read with a small buffer - demonstrates that excess bytes are discarded per chunk
+        let mut output = Vec::new();
         let mut buffer = [0u8; 10];
-        let n = response_stream.read(&mut buffer).await.unwrap();
 
-        // We should only get the first 10 bytes
-        assert_eq!(n, 10);
-        assert_eq!(&buffer[..n], b"This is a ");
+        loop {
+            let n = response_stream.read(&mut buffer).await.unwrap();
+            if n == 0 {
+                break;
+            }
+            output.extend_from_slice(&buffer[..n]);
+        }
 
-        // Next read should get 0 bytes (EOF) because the chunk was consumed
-        let n = response_stream.read(&mut buffer).await.unwrap();
-        assert_eq!(n, 0);
+        assert_eq!(output, expected);
     }
 
     #[tokio::test]
@@ -992,11 +1012,9 @@ mod async_std_tests {
     }
 
     #[async_std::test]
-    async fn test_async_read_with_small_buffer() {
-        // Create a stream with a large chunk
-        let chunks = vec![Ok(Bytes::from(
-            "This is a much longer string that won't fit in a small buffer",
-        ))];
+    async fn test_async_read_with_small_buffer_preserves_large_chunk() {
+        let expected = b"This is a much longer string that won't fit in a small buffer";
+        let chunks = vec![Ok(Bytes::copy_from_slice(expected))];
 
         let stream = stream::iter(chunks);
         let data_stream: DataStream = Box::pin(stream);
@@ -1006,17 +1024,18 @@ mod async_std_tests {
             status_code: 200,
         };
 
-        // Read with a small buffer - demonstrates that excess bytes are discarded per chunk
+        let mut output = Vec::new();
         let mut buffer = [0u8; 10];
-        let n = response_stream.read(&mut buffer).await.unwrap();
 
-        // We should only get the first 10 bytes
-        assert_eq!(n, 10);
-        assert_eq!(&buffer[..n], b"This is a ");
+        loop {
+            let n = response_stream.read(&mut buffer).await.unwrap();
+            if n == 0 {
+                break;
+            }
+            output.extend_from_slice(&buffer[..n]);
+        }
 
-        // Next read should get 0 bytes (EOF) because the chunk was consumed
-        let n = response_stream.read(&mut buffer).await.unwrap();
-        assert_eq!(n, 0);
+        assert_eq!(output, expected);
     }
 
     #[async_std::test]


### PR DESCRIPTION
Linked issue: Fixes #437

## Problem
`ResponseDataStream` implemented Tokio `AsyncRead` and async-std `Read` by copying only the bytes that fit in the caller-provided buffer from each stream chunk. If a stream chunk was larger than the read buffer, the unread tail of that chunk was dropped, causing data loss for small-buffer consumers.

## Solution
When a chunk is larger than the caller buffer, preserve the unread tail by re-inserting it at the front of the boxed byte stream before continuing with the original stream. This keeps the existing `ResponseDataStream::bytes()` API and public struct fields intact while fixing both Tokio and async-std read implementations.

## Focused verification
- `cargo test -p rust-s3 --no-default-features --features tokio-native-tls request::request_trait::tests::test_async_read -- --nocapture` — passed: 4 passed, 0 failed.
- `cargo test -p rust-s3 --no-default-features --features async-std-native-tls request::request_trait::async_std_tests::test_async_read -- --nocapture` — passed: 4 passed, 0 failed.

## Risk notes
Low-to-moderate risk area because this touches streaming read semantics. The change is intentionally scoped to `ResponseDataStream` read adapters and does not alter request construction, signing, credentials, provider selection, TLS, or `ResponseDataStream::bytes()`.

## Provider/runtime cordons
- Provider behavior: no provider-specific behavior changed.
- Runtime behavior: focused coverage was run for Tokio/native-tls and async-std/native-tls read implementations.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/durch/rust-s3/457)
<!-- Reviewable:end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue where streamed response data could be partially discarded when reads used buffers smaller than incoming chunks; sequential reads now preserve and return the full payload.

* **Tests**
  * Updated tests to validate that reading in loops returns the complete response for different async runtimes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->