### PR TITLE
Avoid retrying object_exists 404 responses

### DIFF
--- a/s3/src/bucket.rs
+++ b/s3/src/bucket.rs
@@ -1025,17 +1025,8 @@ impl Bucket {
     pub async fn object_exists<S: AsRef<str>>(&self, path: S) -> Result<bool, S3Error> {
         let command = Command::HeadObject;
         let request = RequestImpl::new(self, path.as_ref(), command).await?;
-        let response_data = match request.response_data(false).await {
-            Ok(response_data) => response_data,
-            Err(S3Error::HttpFailWithBody(status_code, error)) => {
-                if status_code == 404 {
-                    return Ok(false);
-                }
-                return Err(S3Error::HttpFailWithBody(status_code, error));
-            }
-            Err(e) => return Err(e),
-        };
-        Ok(response_data.status_code() != 404)
+        let status_code = request.response_status().await?;
+        Ok(status_code != 404)
     }
 
     #[maybe_async::maybe_async]
@@ -3113,9 +3104,73 @@ mod test {
     use crate::{Bucket, PostPolicy};
     use http::header::{CACHE_CONTROL, HeaderMap, HeaderName, HeaderValue};
     use std::env;
+    #[cfg(all(not(feature = "sync"), feature = "with-tokio"))]
+    use std::io::{Read, Write};
+    #[cfg(all(not(feature = "sync"), feature = "with-tokio"))]
+    use std::net::TcpListener;
+    #[cfg(all(not(feature = "sync"), feature = "with-tokio"))]
+    use std::sync::{
+        Arc,
+        atomic::{AtomicUsize, Ordering},
+    };
+    #[cfg(all(not(feature = "sync"), feature = "with-tokio"))]
+    use std::thread;
 
     fn init() {
         let _ = env_logger::builder().is_test(true).try_init();
+    }
+
+    #[cfg(all(not(feature = "sync"), feature = "with-tokio"))]
+    #[tokio::test]
+    async fn test_object_exists_404_does_not_retry() {
+        init();
+
+        let listener = TcpListener::bind("127.0.0.1:0").unwrap();
+        let endpoint = format!("http://{}", listener.local_addr().unwrap());
+        let requests = Arc::new(AtomicUsize::new(0));
+        let request_count = Arc::clone(&requests);
+
+        let server = thread::spawn(move || {
+            let (mut stream, _) = listener.accept().unwrap();
+            request_count.fetch_add(1, Ordering::SeqCst);
+
+            let mut buffer = [0; 2048];
+            let _ = stream.read(&mut buffer).unwrap();
+            stream
+                .write_all(
+                    b"HTTP/1.1 404 Not Found\r\nContent-Length: 0\r\nConnection: close\r\n\r\n",
+                )
+                .unwrap();
+        });
+
+        crate::set_retries(1);
+
+        let credentials = Credentials::new(
+            Some("test_access_key"),
+            Some("test_secret_key"),
+            None,
+            None,
+            None,
+        )
+        .unwrap();
+        let bucket = Bucket::new(
+            "test-bucket",
+            Region::Custom {
+                region: "us-east-1".to_owned(),
+                endpoint,
+            },
+            credentials,
+        )
+        .unwrap()
+        .with_path_style();
+
+        let exists = bucket.object_exists("/missing.txt").await.unwrap();
+
+        crate::set_retries(1);
+        server.join().unwrap();
+
+        assert!(!exists);
+        assert_eq!(requests.load(Ordering::SeqCst), 1);
     }
 
     fn test_aws_credentials() -> Credentials {

--- a/s3/src/request/async_std_backend.rs
+++ b/s3/src/request/async_std_backend.rs
@@ -84,6 +84,47 @@ impl<'a> Request for SurfRequest<'a> {
         Ok(response)
     }
 
+    async fn response_status(&self) -> Result<u16, S3Error> {
+        crate::retry! {
+            async {
+                let headers = self.headers().await?;
+
+                let request = match self.command.http_verb() {
+                    HttpMethod::Get => surf::Request::builder(Method::Get, self.url()?),
+                    HttpMethod::Delete => surf::Request::builder(Method::Delete, self.url()?),
+                    HttpMethod::Put => surf::Request::builder(Method::Put, self.url()?),
+                    HttpMethod::Post => surf::Request::builder(Method::Post, self.url()?),
+                    HttpMethod::Head => surf::Request::builder(Method::Head, self.url()?),
+                };
+
+                let mut request = request.body(self.request_body()?);
+
+                for (name, value) in headers.iter() {
+                    request = request.header(
+                        HeaderName::from_bytes(AsRef::<[u8]>::as_ref(&name).to_vec())
+                            .expect("Could not parse heaeder name"),
+                        HeaderValue::from_bytes(AsRef::<[u8]>::as_ref(&value).to_vec())
+                            .expect("Could not parse header value"),
+                    );
+                }
+
+                let response = request
+                    .send()
+                    .await
+                    .map_err(|e| S3Error::Surf(e.to_string()))?;
+                let status = u16::from(response.status());
+
+                if status == 404 {
+                    Ok(status)
+                } else if cfg!(feature = "fail-on-err") && !response.status().is_success() {
+                    Err(S3Error::HttpFail)
+                } else {
+                    Ok(status)
+                }
+            }.await
+        }
+    }
+
     async fn response_data(&self, etag: bool) -> Result<ResponseData, S3Error> {
         let mut response = crate::retry! {self.response().await}?;
         let status_code = response.status();

--- a/s3/src/request/blocking.rs
+++ b/s3/src/request/blocking.rs
@@ -79,6 +79,43 @@ impl<'a> Request for AttoRequest<'a> {
         Ok(response)
     }
 
+    fn response_status(&self) -> Result<u16, S3Error> {
+        crate::retry! {
+            {
+                let headers = self.headers()?;
+                let mut session = attohttpc::Session::new();
+
+                for (name, value) in headers.iter() {
+                    session.header(HeaderName::from_bytes(name.as_ref())?, value.to_str()?);
+                }
+
+                if let Some(timeout) = self.bucket.request_timeout {
+                    session.timeout(timeout)
+                }
+
+                let request = match self.command.http_verb() {
+                    HttpMethod::Get => session.get(self.url()?),
+                    HttpMethod::Delete => session.delete(self.url()?),
+                    HttpMethod::Put => session.put(self.url()?),
+                    HttpMethod::Post => session.post(self.url()?),
+                    HttpMethod::Head => session.head(self.url()?),
+                };
+
+                let response = request.bytes(&self.request_body()?).send()?;
+                let status = response.status().as_u16();
+
+                if status == 404 {
+                    Ok(status)
+                } else if cfg!(feature = "fail-on-err") && !response.status().is_success() {
+                    let text = response.text()?;
+                    Err(S3Error::HttpFailWithBody(status, text))
+                } else {
+                    Ok(status)
+                }
+            }
+        }
+    }
+
     fn response_data(&self, etag: bool) -> Result<ResponseData, S3Error> {
         let response = crate::retry! {self.response()}?;
         let status_code = response.status().as_u16();

--- a/s3/src/request/request_trait.rs
+++ b/s3/src/request/request_trait.rs
@@ -210,6 +210,10 @@ pub trait Request {
     #[cfg(any(feature = "with-async-std", feature = "with-tokio"))]
     async fn response_data_to_stream(&self) -> Result<ResponseDataStream, S3Error>;
     async fn response_header(&self) -> Result<(Self::HeaderMap, u16), S3Error>;
+    async fn response_status(&self) -> Result<u16, S3Error> {
+        let (_, status_code) = self.response_header().await?;
+        Ok(status_code)
+    }
     fn datetime(&self) -> OffsetDateTime;
     fn bucket(&self) -> Bucket;
     fn command(&self) -> Command<'_>;

--- a/s3/src/request/tokio_backend.rs
+++ b/s3/src/request/tokio_backend.rs
@@ -117,6 +117,56 @@ impl<'a> Request for ReqwestRequest<'a> {
         Ok(response)
     }
 
+    async fn response_status(&self) -> Result<u16, S3Error> {
+        retry! {
+            async {
+                let headers = self
+                    .headers()
+                    .await?
+                    .iter()
+                    .map(|(k, v)| {
+                        (
+                            reqwest::header::HeaderName::from_str(k.as_str()),
+                            reqwest::header::HeaderValue::from_str(v.to_str().unwrap_or_default()),
+                        )
+                    })
+                    .filter(|(k, v)| k.is_ok() && v.is_ok())
+                    .map(|(k, v)| (k.unwrap(), v.unwrap()))
+                    .collect();
+
+                let client = self.bucket.http_client();
+
+                let method = match self.command.http_verb() {
+                    HttpMethod::Delete => reqwest::Method::DELETE,
+                    HttpMethod::Get => reqwest::Method::GET,
+                    HttpMethod::Post => reqwest::Method::POST,
+                    HttpMethod::Put => reqwest::Method::PUT,
+                    HttpMethod::Head => reqwest::Method::HEAD,
+                };
+
+                let request = client
+                    .request(method, self.url()?.as_str())
+                    .headers(headers)
+                    .body(self.request_body()?);
+
+                let request = request.build()?;
+                let response = client.execute(request).await?;
+                let status = response.status().as_u16();
+
+                if status == 404 {
+                    return Ok(status);
+                }
+
+                if cfg!(feature = "fail-on-err") && !response.status().is_success() {
+                    let text = response.text().await?;
+                    return Err(S3Error::HttpFailWithBody(status, text));
+                }
+
+                Ok(status)
+            }.await
+        }
+    }
+
     async fn response_data(&self, etag: bool) -> Result<ResponseData, S3Error> {
         let response = retry! {self.response().await }?;
         let status_code = response.status().as_u16();


### PR DESCRIPTION
Linked issue: Fixes #444

## Problem
`Bucket::object_exists` used `response_data(false)`, whose backend path wraps `response()` in `retry!`. With `fail-on-err`, an expected HEAD 404 is converted to an error before `object_exists` can classify it, so the retry macro delays and logs warnings for a terminal “object missing” result.

## Solution
Add an internal `Request::response_status` hook for status-only calls and have `object_exists` use it. Built-in tokio, async-std, and sync backends classify status 404 as `Ok(404)` before `retry!` sees an error, while preserving existing `fail-on-err` behavior for non-404 failures. `object_exists` now returns `Ok(false)` for 404 and `Ok(true)` for any other successful status.

## Focused verification
- `cargo test -p rust-s3 test_object_exists_404_does_not_retry --features tokio-native-tls -- --nocapture` — passed; regression test observed exactly one local HEAD request for a 404.
- `cargo check -p rust-s3 --features tokio-native-tls,fail-on-err` — passed.
- `cargo check -p rust-s3 --no-default-features --features sync-native-tls,fail-on-err` — passed.
- `cargo check -p rust-s3 --no-default-features --features async-std-native-tls,fail-on-err` — passed.

## Risk notes
- Retry behavior is preserved for transient request errors because `response_status` remains wrapped in `retry!`.
- `fail-on-err` semantics for ordinary response/body methods are unchanged; only `object_exists` moves to the status-only path.
- Provider/runtime cordons: no signing, credential resolution, URL style, or public `Bucket` API changes. The new trait method has a default implementation to avoid breaking external implementors, with built-in backend overrides for the no-retry 404 behavior.

## Self-review
- Correctness: expected HEAD 404 is terminal `Ok(false)` before retry; non-404 failures still return errors through backend fail-on-err logic.
- Compatibility: public `object_exists` signature and ordinary method behavior unchanged.
- Risk area: request backend code duplicated status-only request construction; focused checks covered tokio, async-std, and sync feature splits.
- Missing tests: focused regression is tokio-backed only; async-std/sync are compile-checked but not behavior-tested with local servers.
- Merge readiness: ready for maintainer review; I did not approve or merge this PR.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/durch/rust-s3/458)
<!-- Reviewable:end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Object-existence checks now treat 404 responses as "not found" immediately, avoiding extra retries and reducing false-positive results.
  * Status-only request path added to streamline status handling and error conversion.

* **Tests**
  * New test ensures a single request is made and that a 404 response yields a false "exists" result.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->