### PR TITLE
fix: exclude content-length and content-type from GetObjectRange signed headers

### DIFF
--- a/s3/src/request/request_trait.rs
+++ b/s3/src/request/request_trait.rs
@@ -738,6 +738,7 @@ pub trait Request {
             Command::ListObjectsV2 { .. } => {}
             Command::HeadObject => {}
             Command::GetObject => {}
+            Command::GetObjectRange { .. } => {}
             Command::GetObjectTagging => {}
             Command::GetBucketLocation => {}
             Command::ListBuckets => {}


### PR DESCRIPTION
## Problem

`GetObjectRange` (ranged GET) requests fail with `SignatureDoesNotMatch` on Cloudflare R2 and other S3-compatible backends.

The `headers()` method in `request_trait.rs` has a skip-list of commands that should not include `content-length` and `content-type` headers. `GetObjectRange` is missing from this list, so it falls through to the catch-all `_ =>` arm that adds `content-length: 0` and `content-type: text/plain`.

These headers get included in the AWS4-HMAC-SHA256 canonical request. AWS S3 tolerates this, but Cloudflare R2 (and potentially other backends) reject the signature.

## Fix

Add `Command::GetObjectRange { .. } => {}` to the match arm alongside `GetObject`, so both commands produce consistent unsigned headers.

One-line change — no behavioral change for any other command.

## Related

- #452 addresses the same issue with a broader `has_body()` refactor. This PR is a minimal targeted fix as an alternative.
- Downstream impact: Stalwart mail server is affected when using R2 for blob storage — attachment downloads via JMAP fail because `get_blob_section()` triggers range requests.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/durch/rust-s3/459)
<!-- Reviewable:end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed S3 Range requests to correctly exclude Content-Length and Content-Type headers, ensuring proper handling of partial file downloads.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->