### PR TITLE
Update dependencies

### DIFF
--- a/aws-creds/Cargo.toml
+++ b/aws-creds/Cargo.toml
@@ -9,6 +9,7 @@ keywords = ["AWS", "S3", "Wasabi", "Minio", "R2"]
 license = "MIT"
 documentation = "https://docs.rs/aws-creds/latest/awscreds/"
 edition = "2021"
+rust-version = "1.88.0"
 
 [lib]
 name = "awscreds"

--- a/aws-creds/Cargo.toml
+++ b/aws-creds/Cargo.toml
@@ -22,7 +22,7 @@ attohttpc = { version = "0.30", default-features = false, features = [
     "json",
 ], optional = true }
 url = "2"
-quick-xml = { version = "0.38", features = ["serialize"] }
+quick-xml = { version = "0.39", features = ["serialize"] }
 serde = { version = "1", features = ["derive"] }
 time = { version = "^0.3.6", features = ["serde", "serde-well-known"] }
 log = "0.4"

--- a/aws-region/Cargo.toml
+++ b/aws-region/Cargo.toml
@@ -9,6 +9,7 @@ keywords = ["Amazon", "AWS", "S3", "R2", "Minio"]
 license = "MIT"
 documentation = "https://docs.rs/aws-region/latest/awsregion/"
 edition = "2021"
+rust-version = "1.88.0"
 
 [lib]
 name = "awsregion"

--- a/s3/Cargo.toml
+++ b/s3/Cargo.toml
@@ -58,7 +58,7 @@ http = "1"
 log = "0.4"
 maybe-async = { version = "0.2" }
 md5 = "0.8"
-minidom = { version = "0.16", optional = true }
+minidom = { version = "0.18", optional = true }
 percent-encoding = "2"
 quick-xml = { version = "0.39", features = ["serialize"] }
 reqwest = { version = "0.12", optional = true, features = [

--- a/s3/Cargo.toml
+++ b/s3/Cargo.toml
@@ -9,6 +9,7 @@ keywords = ["S3", "Wasabi", "Minio", "GCP", "R2"]
 license = "MIT"
 documentation = "https://docs.rs/rust-s3/latest/s3/"
 edition = "2024"
+rust-version = "1.88.0"
 
 [lib]
 name = "s3"

--- a/s3/Cargo.toml
+++ b/s3/Cargo.toml
@@ -61,7 +61,7 @@ md5 = "0.8"
 minidom = { version = "0.18", optional = true }
 percent-encoding = "2"
 quick-xml = { version = "0.39", features = ["serialize"] }
-reqwest = { version = "0.12", optional = true, features = [
+reqwest = { version = "0.13", optional = true, features = [
     "stream",
 ], default-features = false }
 serde = "1"
@@ -96,7 +96,7 @@ tags = ["minidom"]
 http-credentials = ["aws-creds/http-credentials"]
 
 tokio-native-tls = ["aws-creds/native-tls", "reqwest/native-tls", "with-tokio"]
-tokio-rustls-tls = ["aws-creds/rustls-tls", "reqwest/rustls-tls", "with-tokio"]
+tokio-rustls-tls = ["aws-creds/rustls-tls", "reqwest/rustls-no-provider", "with-tokio"]
 
 async-std-native-tls = [
     "aws-creds/native-tls",

--- a/s3/Cargo.toml
+++ b/s3/Cargo.toml
@@ -53,7 +53,7 @@ bytes = { version = "1.2" }
 cfg-if = "1"
 futures-util = { version = "0.3", optional = true, default-features = false }
 hex = "0.4"
-hmac = "0.12"
+hmac = "0.13"
 http = "1"
 log = "0.4"
 maybe-async = { version = "0.2" }
@@ -67,7 +67,7 @@ reqwest = { version = "0.12", optional = true, features = [
 serde = "1"
 serde_derive = "1"
 serde_json = "1"
-sha2 = "0.10"
+sha2 = "0.11"
 surf = { version = "2", optional = true, default-features = false }
 sysinfo = {version = "0.37.0", optional = true }
 thiserror = { version = "2", default-features = false }

--- a/s3/Cargo.toml
+++ b/s3/Cargo.toml
@@ -60,7 +60,7 @@ maybe-async = { version = "0.2" }
 md5 = "0.8"
 minidom = { version = "0.16", optional = true }
 percent-encoding = "2"
-quick-xml = { version = "0.38", features = ["serialize"] }
+quick-xml = { version = "0.39", features = ["serialize"] }
 reqwest = { version = "0.12", optional = true, features = [
     "stream",
 ], default-features = false }

--- a/s3/src/post_policy.rs
+++ b/s3/src/post_policy.rs
@@ -32,6 +32,7 @@ use crate::{Bucket, LONG_DATETIME, signing};
 
 use awscreds::Rfc3339OffsetDateTime;
 use awscreds::error::CredentialsError;
+use hmac::KeyInit;
 use serde::ser;
 use serde::ser::{Serialize, SerializeMap, SerializeSeq, SerializeTuple, Serializer};
 use std::borrow::Cow;

--- a/s3/src/request/request_trait.rs
+++ b/s3/src/request/request_trait.rs
@@ -1,6 +1,6 @@
 use base64::Engine;
 use base64::engine::general_purpose;
-use hmac::Mac;
+use hmac::{KeyInit, Mac};
 use quick_xml::se::to_string;
 use std::collections::HashMap;
 #[cfg(any(feature = "with-tokio", feature = "with-async-std"))]

--- a/s3/src/signing.rs
+++ b/s3/src/signing.rs
@@ -32,7 +32,7 @@
 use std::collections::HashMap;
 use std::str;
 
-use hmac::{Hmac, Mac};
+use hmac::{Hmac, KeyInit, Mac};
 use http::HeaderMap;
 use percent_encoding::{AsciiSet, CONTROLS, utf8_percent_encode};
 use sha2::{Digest, Sha256};


### PR DESCRIPTION
Updated various dependencies. No user-facing breaking changes observed. All tests pass.

While I was at it, I noticed the project did not have an MSRV set. I checked what the MSRV was prior to crate update using [cargo-msrv](https://github.com/foresterre/cargo-msrv), it was 1.88.0. After the changes, it did not change.

Note:
I opted not to update [sysinfo](https://github.com/GuillaumeGomez/sysinfo) as it would bump the MSRV to 1.95.0 per [this commit](https://github.com/GuillaumeGomez/sysinfo/commit/0864b7d00972d1689f786a4f57c7c7834519cd4f).

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/durch/rust-s3/460)
<!-- Reviewable:end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated minimum Rust version requirement to 1.88.0 across all crates.
  * Upgraded multiple dependencies including quick-xml, hmac, reqwest, sha2, minidom, aws-creds, and aws-region to their latest versions.
  * Adjusted TLS feature configuration for improved compatibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->