### PR TITLE
fix: exclude content-length and content-type from DeleteObject signed…

### DIFF
--- a/s3/src/request/request_trait.rs
+++ b/s3/src/request/request_trait.rs
@@ -741,6 +741,7 @@ pub trait Request {
             Command::GetObjectTagging => {}
             Command::GetBucketLocation => {}
             Command::ListBuckets => {}
+            Command::DeleteObject => {}
             _ => {
                 headers.insert(
                     CONTENT_LENGTH,


### PR DESCRIPTION
 `DeleteObject` is missing from the skip-list in `request_trait.rs` `headers()`, so requests get `content-length: 0` and `content-type: text/plain` signed.

  L7 proxies strip `Content-Length: 0` per RFC 7230 §3.3.2 so you get a signature mismatch.

  So this merge request strips this header on delete request.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/durch/rust-s3/465)
<!-- Reviewable:end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of delete requests to ensure they are properly formatted without unnecessary headers, fixing an issue where delete operations may have been incorrectly processed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->