### PR TITLE
fix: do not sign Content-Length/Content-Type on bodyless DELETE requests

### DIFF
--- a/s3/src/request/request_trait.rs
+++ b/s3/src/request/request_trait.rs
@@ -741,6 +741,16 @@ pub trait Request {
             Command::GetObjectTagging => {}
             Command::GetBucketLocation => {}
             Command::ListBuckets => {}
+            // Bodyless DELETE requests must not sign Content-Length/Content-Type:
+            // the HTTP client never transmits them, so strict SigV4 validators
+            // (e.g. Cloudflare R2) reconstruct a different canonical request and
+            // reject with SignatureDoesNotMatch (see issue #466).
+            Command::DeleteObject
+            | Command::DeleteObjectTagging
+            | Command::AbortMultipartUpload { .. }
+            | Command::DeleteBucket
+            | Command::DeleteBucketCors { .. }
+            | Command::DeleteBucketLifecycle => {}
             _ => {
                 headers.insert(
                     CONTENT_LENGTH,


### PR DESCRIPTION
Fixes #466.

## Problem

`headers()` in `request_trait.rs` falls through to the catch-all arm for DELETE commands and inserts `Content-Length: 0` and `Content-Type: text/plain` into the signed header map. Since a DELETE has no body, the HTTP client never actually transmits those headers, so the canonical request signed by rust-s3 differs from the one the server reconstructs.

AWS S3 tolerates the discrepancy, which is why this goes unnoticed there. Cloudflare R2 enforces SigV4 strictly and rejects every DELETE with `403 SignatureDoesNotMatch` — PUT/GET/HEAD work fine, but no object can ever be deleted on R2.

## Fix

Skip inserting `Content-Length`/`Content-Type` for all bodyless DELETE commands: `DeleteObject`, `DeleteObjectTagging`, `AbortMultipartUpload`, `DeleteBucket`, `DeleteBucketCors` and `DeleteBucketLifecycle`. (`DeleteObjects` is a POST with an XML body and keeps its headers.)

## Testing

Verified in production against Cloudflare R2 (Stalwart mail server, which had been unable to purge any blob on R2): with this patch, `delete_object` succeeds — a backlog of ~2.8k objects that had been failing with `SignatureDoesNotMatch` was deleted without a single error. Behaviour against AWS S3 is unchanged, since the headers were no-ops there.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/durch/rust-s3/467)
<!-- Reviewable:end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved request header handling for delete-style operations so they no longer include unnecessary `Content-Length` or `Content-Type` headers.
  * This makes bodyless requests more consistent and better aligned with expected service behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->