### PR TITLE
deps: bump quick-xml to 0.41 to avoid RUSTSEC-2026-019{4,5}

### DIFF
--- a/aws-creds/Cargo.toml
+++ b/aws-creds/Cargo.toml
@@ -22,7 +22,7 @@ attohttpc = { version = "0.30", default-features = false, features = [
     "json",
 ], optional = true }
 url = "2"
-quick-xml = { version = "0.38", features = ["serialize"] }
+quick-xml = { version = "0.41", features = ["serialize"] }
 serde = { version = "1", features = ["derive"] }
 time = { version = "^0.3.6", features = ["serde", "serde-well-known"] }
 log = "0.4"

--- a/s3/Cargo.toml
+++ b/s3/Cargo.toml
@@ -60,7 +60,7 @@ maybe-async = { version = "0.2" }
 md5 = "0.8"
 minidom = { version = "0.16", optional = true }
 percent-encoding = "2"
-quick-xml = { version = "0.38", features = ["serialize"] }
+quick-xml = { version = "0.41", features = ["serialize"] }
 reqwest = { version = "0.12", optional = true, features = [
     "stream",
 ], default-features = false }


### PR DESCRIPTION
This patch bumps the [`quick-xml` crate](https://crates.io/crates/quick-xml) dependency from a static `0.38` to `0.41` in both the `aws-creds` and `s3` crates to avoid [RUSTSEC-2026-0194](https://rustsec.org/advisories/RUSTSEC-2026-0194.html) and [RUSTSEC-2026-0195](https://rustsec.org/advisories/RUSTSEC-2026-0195.html).

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/durch/rust-s3/468)
<!-- Reviewable:end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated an XML processing dependency to a newer version in multiple components.
  * This helps keep the app current with upstream improvements and may improve reliability when working with XML-based data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->