### PR TITLE
fix: keep the endpoint path out of the Host header

### DIFF
--- a/s3/src/request/request_trait.rs
+++ b/s3/src/request/request_trait.rs
@@ -206,6 +206,20 @@ impl async_std::io::Read for ResponseDataStream {
     }
 }
 
+/// The authority of an endpoint host, dropping any path that follows it.
+///
+/// A custom endpoint may carry a path, as Supabase Storage's
+/// `https://<project>.supabase.co/storage/v1/s3` does, and `Region::host`
+/// keeps it so that `Bucket::url` can place the bucket and key underneath.
+/// RFC 9110 §7.2 defines `Host` as `uri-host [ ":" port ]`, so that path
+/// cannot travel in the header.
+fn authority_of(host: &str) -> &str {
+    match host.find('/') {
+        Some(position) => &host[..position],
+        None => host,
+    }
+}
+
 #[maybe_async::maybe_async]
 pub trait Request {
     type Response;
@@ -291,7 +305,7 @@ pub trait Request {
     }
 
     fn host_header(&self) -> String {
-        self.bucket().host()
+        authority_of(&self.bucket().host()).to_string()
     }
 
     #[maybe_async::async_impl]
@@ -875,6 +889,27 @@ mod tests {
     use bytes::Bytes;
     use futures_util::stream;
     use tokio::io::AsyncReadExt;
+
+    #[test]
+    fn test_authority_of_keeps_a_plain_host() {
+        assert_eq!(
+            authority_of("s3.eu-central-1.amazonaws.com"),
+            "s3.eu-central-1.amazonaws.com"
+        );
+        assert_eq!(authority_of("127.0.0.1:9000"), "127.0.0.1:9000");
+    }
+
+    #[test]
+    fn test_authority_of_drops_an_endpoint_path() {
+        assert_eq!(
+            authority_of("project.supabase.co/storage/v1/s3"),
+            "project.supabase.co"
+        );
+        assert_eq!(
+            authority_of("127.0.0.1:54321/storage/v1/s3"),
+            "127.0.0.1:54321"
+        );
+    }
 
     #[tokio::test]
     async fn test_async_read_implementation() {


### PR DESCRIPTION
Fixes #473.

`Region::Custom` accepts an endpoint that carries a path, and `Region::host` keeps that path so `Bucket::url` can place the bucket and key underneath it. `host_header` returned the same string, so the path travelled in the `Host` header as well:

```
PUT /storage/v1/s3/media/0000….bin HTTP/1.1
host: project.supabase.co/storage/v1/s3
```

RFC 9110 §7.2 defines `Host` as `uri-host [ ":" port ]`. A server that checks answers `400 Bad Request` with no body, before any signature is verified, so every request to such an endpoint fails and nothing says why. Supabase Storage's S3 endpoint is `https://<project>.supabase.co/storage/v1/s3` and is unusable for this reason. AWS, MinIO and R2 have no path in their endpoints, so nothing had exercised the case.

## What changed

`host_header` now takes the authority. `Region::host` is untouched, so the request line keeps the endpoint path it needs, and `Bucket::url`, `path_style_host` and `subdomain_style_host` behave as before. `host_header` feeds the `HOST` header only (`request_trait.rs:406`, `:729`), so nothing else sees the narrower value.

## Verification

Against a Supabase Storage bucket, before and after, with the same 300 KB object:

| | before | after |
|---|---|---|
| `put_object_with_content_type` | `400 Bad request` | `200` |
| `head_object` | unreachable | `200`, `content_length=300000` |
| `get_object` | unreachable | `200`, 300000 bytes |
| `get_object_range(0, 1023)` | unreachable | `206`, 1024 bytes |
| `get_object_range(100_000, 200_000)` | unreachable | `206`, 100001 bytes |

MinIO passes the same five before and after.

`cargo fmt --all -- --check` is clean, clippy is clean for `with-tokio,tokio-rustls-tls`, and `cargo test --lib` passes 61 with 20 ignored. Two unit tests cover the split.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/durch/rust-s3/474)
<!-- Reviewable:end -->
